### PR TITLE
feat: deploy konflate

### DIFF
--- a/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: konflate
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: konflate
+  interval: 1h
+  values:
+    config:
+      repo: github://alex-matthews/home-ops
+    httpRoute:
+      enabled: true
+      parentRefs:
+        - name: envoy-internal
+          namespace: network
+      hostnames:
+        - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+    monitoring:
+      serviceMonitor:
+        enabled: true
+    resources:
+      requests:
+        cpu: 50m
+      limits:
+        cpu: 4000m
+        memory: 4Gi

--- a/kubernetes/apps/flux-system/konflate/app/kustomization.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/flux-system/konflate/app/ocirepository.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: konflate
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.1.6
+  url: oci://ghcr.io/home-operations/charts/konflate

--- a/kubernetes/apps/flux-system/konflate/ks.yaml
+++ b/kubernetes/apps/flux-system/konflate/ks.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: konflate
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/flux-system/konflate/app
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: flux-system

--- a/kubernetes/apps/flux-system/kustomization.yaml
+++ b/kubernetes/apps/flux-system/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - ./namespace.yaml
   - ./flux-instance/ks.yaml
   - ./flux-operator/ks.yaml
+  - ./konflate/ks.yaml


### PR DESCRIPTION
## Summary
- Add Konflate 0.1.6 under flux-system using the existing app/OCIRepository/Kustomization layout.
- Configure Konflate for anonymous read-only review of github://alex-matthews/home-ops.
- Expose it internally via envoy-internal at konflate.${SECRET_DOMAIN} and enable ServiceMonitor support.

## Validation
- oxfmt --check .
- kubectl kustomize kubernetes/apps/flux-system
- kubectl kustomize kubernetes/apps/flux-system/konflate/app
- FLATE_PATH=./kubernetes/flux/cluster flate test all --allow-missing-secrets: 166 passed, 0 failed
- FLATE_BASE=main FLATE_OUTPUT=json FLATE_PATH=./kubernetes/flux/cluster flate diff images returned ghcr.io/home-operations/konflate:0.1.6
- GitHub Actions: Flate, Image Pull, and Labeler checks pass on 1ba1316d

## Notes
- This does not add forge tokens, webhooks, or push refresh secrets; Konflate will use its built-in polling/backstop behavior against the public repository.