### PR TITLE
fix(renovate): allow vulnerability alert reads

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -54,6 +54,7 @@ jobs:
           permission-contents: write
           permission-issues: write
           permission-pull-requests: write
+          permission-vulnerability-alerts: read
           permission-workflows: write
 
       - name: Checkout


### PR DESCRIPTION
## Summary
- request read access to vulnerability alerts when minting the bot-ler GitHub App token for Renovate
- matches the Home Operations reference pattern used by onedr0p/home-ops and buroa/k8s-gitops

## Notes
The bot-ler GitHub App installation also needs the corresponding read-only Vulnerability alerts / Dependabot alerts repository permission in GitHub app settings. This workflow change lets the generated installation token request that permission once it is granted.

## Validation
- oxfmt --check .
- zizmor .github/workflows/renovate.yaml
- lefthook run pre-commit