### PR TITLE
feat(unifi-dns): use home-operations webhook

### DIFF
--- a/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
@@ -15,8 +15,8 @@ spec:
       name: webhook
       webhook:
         image:
-          repository: ghcr.io/kashalls/external-dns-unifi-webhook
-          tag: v0.9.0@sha256:22f4106f44a0b9ac3c97cf29bbfef93026c1164492152dc797a1d6dc86ddfbb5
+          repository: ghcr.io/home-operations/external-dns-unifi-webhook
+          tag: 0.10.2@sha256:1f51f841e217d8bc6481655481ce82e0f0be70ad359c23d7d866d53a51d87fa9
         env:
           - name: UNIFI_HOST
             value: https://192.168.1.1


### PR DESCRIPTION
## Summary
- migrate the UniFi ExternalDNS webhook image from `ghcr.io/kashalls/external-dns-unifi-webhook` to `ghcr.io/home-operations/external-dns-unifi-webhook`
- pin the current Home Operations release `0.10.2` by digest
- leave `UNIFI_HOST`, `txtOwnerId`, and `txtPrefix` unchanged to avoid DNS ownership churn

## Notes
- upstream requires ExternalDNS >= v0.21.0 and UniFi Network >= 10.3.58 because the webhook now uses the official UniFi Network Integration API

## Validation
- `oxfmt --check .`
- `kubectl kustomize kubernetes/apps/network/unifi-dns/app`
- `FLATE_PATH=./kubernetes/flux/cluster flate build ks --namespace network unifi-dns`
- `FLATE_PATH=./kubernetes/flux/cluster flate test all --allow-missing-secrets`
- `lefthook run pre-commit`