### PR TITLE
ci(renovate): grant status permissions

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -51,9 +51,11 @@ jobs:
         with:
           client-id: ${{ secrets.BOT_APP_CLIENT_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          permission-checks: write
           permission-contents: write
           permission-issues: write
           permission-pull-requests: write
+          permission-statuses: write
           permission-vulnerability-alerts: read
           permission-workflows: write
 


### PR DESCRIPTION
## Summary

- Request `checks: write` and `statuses: write` on the Renovate GitHub App token.
- Fix the latest Renovate 403 from `POST /statuses`, where GitHub reported `x-accepted-github-permissions: statuses=write`.

## Validation

- `oxfmt --check .github/workflows/renovate.yaml`
- `zizmor --offline .github/workflows/renovate.yaml`
- `lefthook run pre-commit`