### PR TITLE
fix(kubernetes): tune logs collector and DNS TXT prefixes

### DIFF
--- a/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
       - crd
       - gateway-httproute
     txtOwnerId: default
-    txtPrefix: k8s.
+    txtPrefix: k8s.%{record_type}-
     domainFilters:
       - ${SECRET_DOMAIN}
     serviceMonitor:

--- a/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/unifi-dns/app/helmrelease.yaml
@@ -43,7 +43,7 @@ spec:
       - gateway-httproute
       - service
     txtOwnerId: default
-    txtPrefix: k8s.
+    txtPrefix: k8s.%{record_type}-
     domainFilters:
       - ${SECRET_DOMAIN}
     serviceMonitor:

--- a/kubernetes/apps/observability/victoria-logs/collector/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/collector/helmrelease.yaml
@@ -18,3 +18,12 @@ spec:
       enabled: true
     remoteWrite:
       - url: http://victoria-logs.observability.svc.cluster.local:9428
+        maxDiskUsagePerURL: 10GB
+    collector:
+      streamFields:
+        - kubernetes.pod_name
+        - kubernetes.pod_namespace
+        - kubernetes.container_name
+        - kubernetes.pod_labels.app.kubernetes.io/name
+    extraArgs:
+      "kubernetesCollector.decolorizeFields": _msg


### PR DESCRIPTION
## Summary
- add Victoria Logs collector streamFields for pod/container metadata
- add maxDiskUsagePerURL for collector remote write buffering
- decolorize _msg and change both ExternalDNS controllers to record-type TXT prefixes

## Validation
- kubectl kustomize kubernetes/apps/observability/victoria-logs/collector
- kubectl kustomize kubernetes/apps/network/cloudflare-dns/app
- kubectl kustomize kubernetes/apps/network/unifi-dns/app
- git diff --check HEAD~1..HEAD