### PR TITLE
feat: deploy maintainerr

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./autobrr/ks.yaml
   - ./bazarr/ks.yaml
   - ./brrpolice/ks.yaml
+  - ./maintainerr/ks.yaml
   - ./plex/ks.yaml
   - ./prowlarr/ks.yaml
   - ./qbittorrent/ks.yaml

--- a/kubernetes/apps/default/maintainerr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/maintainerr/app/helmrelease.yaml
@@ -1,0 +1,86 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: maintainerr
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: maintainerr
+  interval: 1h
+  values:
+    controllers:
+      maintainerr:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/maintainerr/maintainerr
+              tag: 3.15.3@sha256:ab621826a54bf1a4388e7de9d7c3dadd365d9abf39f26e485503e8f10453ad2e
+            env:
+              TZ: Pacific/Auckland
+              UI_HOSTNAME: 0.0.0.0
+              UI_PORT: &port 80
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health/live
+                    port: *port
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health/ready
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1032
+        runAsGroup: 100
+        fsGroup: 100
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+    persistence:
+      config:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /opt/data
+      tmp:
+        type: emptyDir

--- a/kubernetes/apps/default/maintainerr/app/kustomization.yaml
+++ b/kubernetes/apps/default/maintainerr/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/default/maintainerr/app/ocirepository.yaml
+++ b/kubernetes/apps/default/maintainerr/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: maintainerr
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/maintainerr/ks.yaml
+++ b/kubernetes/apps/default/maintainerr/ks.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: maintainerr
+spec:
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/default/maintainerr/app
+  postBuild:
+    substitute:
+      APP: maintainerr
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: default
+  wait: false


### PR DESCRIPTION
## Summary
- add Maintainerr via app-template with pinned image digest
- provision VolSync-backed app data at /opt/data using the standard VolSync PVC defaults
- run the pod with the NAS-aligned VolSync app identity, 1032:100
- expose maintainerr on the internal Gateway route

## Notes
- uses `ghcr.io/maintainerr/maintainerr:3.15.3` and the current multi-arch index digest
- keeps the local port-80 shape used by this repo while preserving the current Maintainerr image namespace
- uses upstream-documented `/api/health/live` and `/api/health/ready` probes; upstream added these in `3.14.0`, so the stale `3.12.1` pin was refreshed before merge
- uses an emptyDir `/tmp` mount for the read-only root filesystem
- Maintainerr stores runtime configuration in the app; first-run Plex/Seerr settings are completed through the internal route and persisted at `/opt/data`

## Validation
- `mise exec -- kubectl kustomize /Users/alex/home-ops-pr1220/kubernetes/apps/default/maintainerr/app`
- `mise exec -- kubectl kustomize /Users/alex/home-ops-pr1220/kubernetes/apps/default`
- `mise exec --no-deps -- oxfmt --check /Users/alex/home-ops-pr1220/kubernetes/apps/default/kustomization.yaml /Users/alex/home-ops-pr1220/kubernetes/apps/default/maintainerr`
- `mise exec -- flate test all -p /Users/alex/home-ops-pr1220/kubernetes/flux/cluster --allow-missing-secrets`
- `MINIJINJA_CONFIG_FILE=/Users/alex/home-ops-pr1220/.minijinja.toml flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets`
- `docker buildx imagetools inspect ghcr.io/maintainerr/maintainerr:3.15.3`

## Validation notes
- local `flate diff images` could not run from the linked worktree due `resolve HEAD: reference not found`; PR Image Pull reruns after this push and should be used as the image-diff check
- offline flate render warns about missing `cloudflare-tunnel-id-secret`, unrelated to Maintainerr
