### PR TITLE
style(gatus): align sidecar values ordering

### DIFF
--- a/kubernetes/apps/observability/gatus-sidecar/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus-sidecar/app/helmrelease.yaml
@@ -13,11 +13,11 @@ spec:
     deploymentAnnotations:
       reloader.stakater.com/auto: "true"
     gatus:
-      image:
-        digest: sha256:c5f210d095fa78e6efaa20ffeb14803f2ba4f10615e16a6d12087697149617f0
       delayStartSeconds: "5"
       env:
         TZ: Pacific/Auckland
+      image:
+        digest: sha256:c5f210d095fa78e6efaa20ffeb14803f2ba4f10615e16a6d12087697149617f0
     sidecar:
       kinds:
         httproute:


### PR DESCRIPTION
## Summary

- align `gatus-sidecar` chart values ordering with onedr0p's current reference layout
- keep the existing pinned Gatus image digest unchanged

## Validation

- `oxfmt --check kubernetes/apps/observability/gatus-sidecar/app/helmrelease.yaml`
- `kubectl kustomize kubernetes/apps/observability/gatus-sidecar/app`
- `git diff --check`
