### PR TITLE
feat(echo): switch to home-operations chart

### DIFF
--- a/kubernetes/apps/network/echo/app/helmrelease.yaml
+++ b/kubernetes/apps/network/echo/app/helmrelease.yaml
@@ -10,62 +10,24 @@ spec:
     name: echo
   interval: 1h
   values:
-    controllers:
-      echo:
-        strategy: RollingUpdate
-        containers:
-          app:
-            image:
-              repository: ghcr.io/mendhak/http-https-echo
-              tag: 40
-            env:
-              HTTP_PORT: &port 80
-              LOG_WITHOUT_NEWLINE: true
-              LOG_IGNORE_PATH: /healthz
-              PROMETHEUS_ENABLED: true
-            probes:
-              liveness: &probes
-                enabled: true
-                custom: true
-                spec:
-                  httpGet:
-                    path: /healthz
-                    port: *port
-                  initialDelaySeconds: 0
-                  periodSeconds: 10
-                  timeoutSeconds: 1
-                  failureThreshold: 3
-              readiness: *probes
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: { drop: ["ALL"] }
-            resources:
-              requests:
-                cpu: 10m
-              limits:
-                memory: 64Mi
-    defaultPodOptions:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-    service:
-      app:
-        ports:
-          http:
-            port: *port
-    serviceMonitor:
-      app:
-        endpoints:
-          - port: http
-    route:
-      app:
-        annotations:
-          gatus.home-operations.com/endpoint: |-
-            conditions: ["[STATUS] == 200"]
-        hostnames:
-          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-        parentRefs:
-          - name: envoy-external
-            namespace: network
+    replicaCount: 2
+    config:
+      kubernetes: true
+    httpRoute:
+      enabled: true
+      annotations:
+        gatus.home-operations.com/endpoint: |-
+          conditions: ["[STATUS] == 200"]
+      hostnames:
+        - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+      parentRefs:
+        - name: envoy-external
+          namespace: network
+    monitoring:
+      serviceMonitor:
+        enabled: true
+    resources:
+      requests:
+        cpu: 10m
+      limits:
+        memory: 64Mi

--- a/kubernetes/apps/network/echo/app/ocirepository.yaml
+++ b/kubernetes/apps/network/echo/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 5.0.1
-  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+    tag: 0.1.0
+  url: oci://ghcr.io/home-operations/charts/echo


### PR DESCRIPTION
## Summary

- migrate `network/echo` from `bjw-s/app-template` and `ghcr.io/mendhak/http-https-echo` to the dedicated `home-operations/echo` chart `0.1.0`
- preserve the existing `echo.${SECRET_DOMAIN}` HTTPRoute through `envoy-external`
- preserve the Gatus endpoint annotation and ServiceMonitor
- keep the existing resource budget of `10m` CPU request and `64Mi` memory limit

## Behavior and cutover notes

- The chart runs two replicas, matching the onedr0p reference.
- `config.kubernetes: true` adds pod, namespace, pod IP, and node metadata to echo responses through the Downward API.
- The chart keeps `automountServiceAccountToken: false`; no Kubernetes API RBAC is introduced.
- Metrics move to the chart's dedicated `metrics` port on `9090`.
- The underlying Deployment selector changes as part of the chart migration. Echo is stateless, but Flux/Helm may need the old `network/echo` Deployment recreated during cutover if Helm reports an immutable selector error.
- This supersedes #1264, which only updates the old `ghcr.io/mendhak/http-https-echo` image.

## Validation

- `oxfmt --check kubernetes/apps/network/echo/app/helmrelease.yaml kubernetes/apps/network/echo/app/ocirepository.yaml`
- `kubectl kustomize kubernetes/apps/network/echo/app`
- `kubectl kustomize kubernetes/apps/network`
- `helm template echo oci://ghcr.io/home-operations/charts/echo --version 0.1.0 --namespace network --values /private/tmp/echo-values.yaml`
- `flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets --base origin/main`
- `flate diff images -p ./kubernetes/flux/cluster -o json --base origin/main`
- `git diff --check`
