### PR TITLE
ci: load ai reviewer policy from base

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -50,6 +50,7 @@ jobs:
         run: |
           head_repo="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.repo.full_name')"
           head_sha="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')"
+          base_ref="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.base.ref')"
           author="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.user.login')"
           draft="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.draft')"
 
@@ -61,6 +62,7 @@ jobs:
 
           echo "eligible=${eligible}" >> "$GITHUB_OUTPUT"
           echo "head_sha=${head_sha}" >> "$GITHUB_OUTPUT"
+          echo "base_ref=${base_ref}" >> "$GITHUB_OUTPUT"
           echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
           echo "checkout_ref=${head_sha}" >> "$GITHUB_OUTPUT"
 
@@ -92,13 +94,20 @@ jobs:
         id: review_context
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.config.outputs.enabled == 'true' }}
         env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
           KONFLATE_URL: ${{ secrets.KONFLATE_URL || vars.KONFLATE_URL }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
           context_file=".github/ai-review-context.md"
+          system_prompt_file=".github/ai-review-system-prompt.effective.md"
           summary_file="${RUNNER_TEMP}/konflate-summary.md"
 
-          cp .github/ai-review-rules.md "${context_file}"
+          gh api "repos/${GITHUB_REPOSITORY}/contents/.github/ai-review-rules.md?ref=${BASE_REF}" \
+            --jq ".content" | base64 --decode > "${context_file}"
+          gh api "repos/${GITHUB_REPOSITORY}/contents/.github/ai-review-system-prompt.md?ref=${BASE_REF}" \
+            --jq ".content" | base64 --decode > "${system_prompt_file}"
+
           {
             echo
             echo "## Current Konflate Summary"
@@ -123,6 +132,7 @@ jobs:
           fi
 
           echo "path=${context_file}" >> "$GITHUB_OUTPUT"
+          echo "system_prompt_path=${system_prompt_file}" >> "$GITHUB_OUTPUT"
 
       - name: Review Renovate PR
         if: ${{ steps.pr.outputs.eligible == 'true' && steps.config.outputs.enabled == 'true' }}
@@ -143,7 +153,7 @@ jobs:
           ai_request_timeout_sec: "300"
           ai_connect_timeout_sec: "10"
           on_model_failure: notice
-          system_prompt_file: .github/ai-review-system-prompt.md
+          system_prompt_file: ${{ steps.review_context.outputs.system_prompt_path }}
           standards_file: ${{ steps.review_context.outputs.path }}
           allowed_source_hosts: ${{ vars.AI_PR_REVIEW_ALLOWED_SOURCE_HOSTS || 'github.com,api.github.com,gitlab.com,registry.terraform.io,artifacthub.io,ghcr.io,hub.docker.com' }}
           publish_mode: review_comment


### PR DESCRIPTION
## Summary

- fetch AI reviewer rules and system prompt from the PR base branch instead of the checked-out Renovate branch
- keep reviewing the PR head SHA, but use current reviewer policy for generated context and system prompt
- fixes stale reviewer behavior on older Renovate PRs that predate prompt/rules changes

## Validation

- oxfmt --check .github/workflows/ai-pr-review.yaml
- zizmor .github/workflows/ai-pr-review.yaml
- git diff --check