### PR TITLE
feat: deploy searxng

### DIFF
--- a/docs/adr/0001-ai-home-ops-workbench.md
+++ b/docs/adr/0001-ai-home-ops-workbench.md
@@ -224,10 +224,11 @@ surface should be smaller and easier to reason about.
 
 ### 5.5 SearXNG first
 
-Deferred. SearXNG does not require PostgreSQL, but it adds operational surface
-and often includes Valkey for limiter support. Start with GitHub, Context7, and
-provider-native search where available. Add SearXNG only if the workbench needs
-a self-hosted metasearch endpoint.
+Initially deferred. The reviewer now has a concrete need for a self-hosted
+metasearch endpoint, so deploy SearXNG behind a public route with Dragonfly as a
+small Redis-compatible limiter backend, one 1Password-backed app secret, and
+JSON search enabled. Keep the Dragonfly data disposable and avoid persistent
+storage unless another consumer creates a durable cache requirement.
 
 ### 5.6 Discord bot or Discord scraping
 
@@ -252,8 +253,8 @@ scraping approaches are not an acceptable design foundation.
 8. Add peer-repository trend summarisation through GitHub-first ingestion.
 9. Add observability and off-cluster MCPs only after trust boundaries and tokens
    are scoped.
-10. Revisit OpenClaw, OpenCode, Open WebUI, SearXNG, and local inference after the
-    minimal workbench has proved useful.
+10. Revisit OpenClaw, OpenCode, Open WebUI, and local inference after the minimal
+    workbench has proved useful.
 
 ## 7. Evaluation Criteria
 

--- a/kubernetes/apps/database/dragonfly-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/database/dragonfly-operator/app/helmrelease.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dragonfly-operator
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: dragonfly-operator
+  interval: 1h
+  values:
+    manager:
+      image:
+        repository: ghcr.io/dragonflydb/operator

--- a/kubernetes/apps/database/dragonfly-operator/app/kustomization.yaml
+++ b/kubernetes/apps/database/dragonfly-operator/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/database/dragonfly-operator/app/ocirepository.yaml
+++ b/kubernetes/apps/database/dragonfly-operator/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: dragonfly-operator
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v1.6.1
+  url: oci://ghcr.io/dragonflydb/dragonfly-operator/helm/dragonfly-operator

--- a/kubernetes/apps/database/dragonfly-operator/ks.yaml
+++ b/kubernetes/apps/database/dragonfly-operator/ks.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: dragonfly-operator
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/database/dragonfly-operator/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: database
+  wait: true

--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: database
+components:
+  - ../../components/alerts
+resources:
+  - ./namespace.yaml
+  - ./dragonfly-operator/ks.yaml

--- a/kubernetes/apps/database/namespace.yaml
+++ b/kubernetes/apps/database/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
   - ./radarr-se/ks.yaml
   - ./recyclarr/ks.yaml
   - ./sabnzbd/ks.yaml
+  - ./searxng/ks.yaml
   - ./seerr/ks.yaml
   - ./sonarr/ks.yaml
   - ./tautulli/ks.yaml

--- a/kubernetes/apps/default/searxng/app/externalsecret.yaml
+++ b/kubernetes/apps/default/searxng/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: searxng
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: searxng-secret
+    template:
+      data:
+        SEARXNG_SECRET: "{{ .SEARXNG_SECRET }}"
+  dataFrom:
+    - extract:
+        key: searxng

--- a/kubernetes/apps/default/searxng/app/helmrelease.yaml
+++ b/kubernetes/apps/default/searxng/app/helmrelease.yaml
@@ -1,0 +1,99 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: searxng
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: searxng
+  interval: 1h
+  values:
+    controllers:
+      searxng:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/searxng/searxng
+              tag: 2026.6.15-cf1410af8@sha256:37a8cc7769c4721b8f252ba935de8f01b7918e58d26b1be18dc87b5330fda65b
+            env:
+              TZ: Pacific/Auckland
+              SEARXNG_BASE_URL: https://search.${SECRET_DOMAIN}
+              SEARXNG_PORT: &port 8080
+              SEARXNG_REDIS_URL: redis://{{ .Release.Name }}-dragonfly:6379
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /stats
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+                add:
+                  - CHOWN
+                  - SETGID
+                  - SETUID
+                  - DAC_OVERRIDE
+            resources:
+              requests:
+                cpu: 10m
+                memory: 256Mi
+              limits:
+                memory: 2Gi
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 977
+        runAsGroup: 977
+        fsGroup: 977
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: searxng
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        annotations:
+          gatus.home-operations.com/endpoint: |-
+            url: https://search.${SECRET_DOMAIN}/stats
+            conditions: ["[STATUS] == 200"]
+        hostnames:
+          - search.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-external
+            namespace: network
+    persistence:
+      config:
+        type: configMap
+        name: searxng-configmap
+        globalMounts:
+          - path: /etc/searxng/settings.yml
+            subPath: settings.yml
+            readOnly: true
+          - path: /etc/searxng/limiter.toml
+            subPath: limiter.toml
+            readOnly: true
+      tmpfs:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/default/searxng/app/kustomization.yaml
+++ b/kubernetes/apps/default/searxng/app/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+configMapGenerator:
+  - name: searxng-configmap
+    files:
+      - ./resources/limiter.toml
+      - ./resources/settings.yml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/default/searxng/app/ocirepository.yaml
+++ b/kubernetes/apps/default/searxng/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: searxng
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/searxng/app/resources/limiter.toml
+++ b/kubernetes/apps/default/searxng/app/resources/limiter.toml
@@ -1,0 +1,13 @@
+[real_ip]
+x_for = 1
+ipv4_prefix = 32
+ipv6_prefix = 48
+
+[botdetection.ip_limit]
+filter_link_local = true
+link_token = false
+
+[botdetection.ip_lists]
+block_ip = []
+pass_ip = ["192.168.0.0/16", "10.0.0.0/8"]
+pass_searxng_org = false

--- a/kubernetes/apps/default/searxng/app/resources/settings.yml
+++ b/kubernetes/apps/default/searxng/app/resources/settings.yml
@@ -1,0 +1,44 @@
+---
+use_default_settings: true
+
+general:
+  instance_name: SearXNG
+
+server:
+  limiter: true
+  image_proxy: true
+  method: GET
+  public_instance: false
+
+search:
+  autocomplete: duckduckgo
+  favicon_resolver: duckduckgo
+  languages:
+    - all
+    - en
+    - en-US
+  formats:
+    - html
+    - json
+
+ui:
+  default_theme: simple
+  infinite_scroll: true
+  query_in_title: true
+  results_on_new_tab: true
+  static_use_hash: true
+  theme_args:
+    simple_style: auto
+
+categories_as_tabs:
+  general:
+  images:
+  videos:
+  map:
+
+enabled_plugins:
+  - Basic Calculator
+  - Hash plugin
+  - Open Access DOI rewrite
+  - Tracker URL remover
+  - Unit converter plugin

--- a/kubernetes/apps/default/searxng/ks.yaml
+++ b/kubernetes/apps/default/searxng/ks.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: searxng
+spec:
+  components:
+    - ../../../../components/dragonfly
+  dependsOn:
+    - name: dragonfly-operator
+      namespace: database
+  healthCheckExprs:
+    - apiVersion: dragonflydb.io/v1alpha1
+      kind: Dragonfly
+      failed: status.phase != 'ready'
+      current: status.phase == 'ready'
+  interval: 1h
+  path: ./kubernetes/apps/default/searxng/app
+  postBuild:
+    substitute:
+      APP: searxng
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: default
+  wait: false

--- a/kubernetes/components/dragonfly/cluster.yaml
+++ b/kubernetes/components/dragonfly/cluster.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/dragonflydb.io/dragonfly_v1alpha1.json
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  name: ${APP}-dragonfly
+spec:
+  image: ghcr.io/dragonflydb/dragonfly:v1.39.0@sha256:0fa01a2b929e704c7a9300d23e7f52002ebd39e90996fb8bb63826aed92fa06f
+  replicas: 1
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities: { drop: ["ALL"] }
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  env:
+    - name: MAX_MEMORY
+      valueFrom:
+        resourceFieldRef:
+          resource: limits.memory
+          divisor: 1Mi
+  args:
+    - --maxmemory=$(MAX_MEMORY)Mi
+  resources:
+    requests:
+      cpu: 10m
+      memory: 50Mi
+    limits:
+      memory: 256Mi

--- a/kubernetes/components/dragonfly/kustomization.yaml
+++ b/kubernetes/components/dragonfly/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./cluster.yaml


### PR DESCRIPTION
## Summary

- deploy SearXNG in `default` using the repo's existing app-template pattern
- add the Dragonfly operator in a new `database` namespace
- add a reusable Dragonfly component and use it as SearXNG's Redis-compatible limiter backend
- expose SearXNG at `search.${SECRET_DOMAIN}` through `envoy-external`
- enable JSON search output for the AI reviewer/workbench path
- update the AI workbench ADR so SearXNG is no longer documented as deferred

## Notes

This now follows the common peer shape more closely: SearXNG gets a public route and `server.limiter: true`, backed by Dragonfly through `SEARXNG_REDIS_URL`.

Konflate reports this as a neutral advisory render because the Dragonfly operator introduces new cluster-wide RBAC. The cautions are expected for this operator:

- `ClusterRoleBinding dragonfly-operator-manager-clusterrolebinding`
- `ClusterRoleBinding dragonfly-operator-proxy-clusterrolebinding`

Material divergences from Jory/KubeSearch examples:

- Dragonfly starts as a single disposable 256Mi replica rather than a 2-3 replica HA/cache cluster.
- No Dragonfly PodMonitor or NetworkPolicy is added yet.
- No persistent storage is added; limiter/cache state is disposable.

The GitHub Actions search endpoint will be:

```text
https://search.${SECRET_DOMAIN}/search
```

After merge and a healthy rollout, set:

```text
AI_PR_REVIEW_SEARCH_URL=https://search.${SECRET_DOMAIN}/search
```

Before merge/reconcile, create a 1Password item named `searxng` with a `SEARXNG_SECRET` field. That feeds `searxng-secret` via External Secrets.

## Validation

- `kustomize build kubernetes/apps/database`
- `kustomize build kubernetes/apps/default/searxng/app`
- `flate build ks --namespace database --output yaml dragonfly-operator`
- `flate build ks --namespace default --output yaml searxng`
- `oxfmt --check kubernetes/apps/database kubernetes/components/dragonfly kubernetes/apps/default/searxng docs/adr/0001-ai-home-ops-workbench.md`
- `flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets`

Flate passed 173 resources. The only warning was the existing offline `cloudflare-tunnel-id-secret` substitution warning.

Konflate rendered 33 added resources across 5 apps and 1 CRD, with the expected Dragonfly operator ClusterRoleBinding cautions noted above.
