### PR TITLE
feat(ai): deploy hermes workbench

### DIFF
--- a/kubernetes/apps/ai/hermes/app/configmap.yaml
+++ b/kubernetes/apps/ai/hermes/app/configmap.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-config
+data:
+  config.yaml: |
+    model:
+      provider: minimax
+      default: MiniMax-M3
+    toolsets:
+      - hermes-cli
+    terminal:
+      backend: local
+      cwd: /opt/data/workspace
+      timeout: 180
+      persistent_shell: true
+    mcp_servers:
+      toolhive:
+        url: http://vmcp-home-ops-workbench.ai.svc.cluster.local:4483/mcp
+        tools:
+          prompts: false
+          resources: false
+    compression:
+      enabled: true
+      threshold: 0.50
+      target_ratio: 0.20
+      protect_last_n: 20
+    agent:
+      max_turns: 60
+      gateway_timeout: 1200
+      restart_drain_timeout: 60
+      api_max_retries: 2
+      reasoning_effort: medium
+    streaming:
+      enabled: false
+    security:
+      redact_secrets: true
+    privacy:
+      redact_pii: true

--- a/kubernetes/apps/ai/hermes/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hermes/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermes
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: hermes-secret
+    template:
+      data:
+        MINIMAX_API_KEY: "{{ .MINIMAX_API_KEY }}"
+  dataFrom:
+    - extract:
+        key: hermes

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -1,0 +1,92 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: hermes
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: hermes
+  interval: 1h
+  values:
+    controllers:
+      hermes:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/nousresearch/hermes-agent
+              tag: v2026.6.5@sha256:9ad3b04ec916ea2c2da22358fd43b024c788d74073210695af88bfc2e63869b4
+            env:
+              HERMES_HOME: /opt/data
+              HOME: /opt/data
+              NO_COLOR: "1"
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
+            args:
+              - gateway
+              - run
+              - --no-supervise
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 100m
+              limits:
+                memory: 2Gi
+          dashboard:
+            image:
+              repository: docker.io/nousresearch/hermes-agent
+              tag: v2026.6.5@sha256:9ad3b04ec916ea2c2da22358fd43b024c788d74073210695af88bfc2e63869b4
+            env:
+              GATEWAY_HEALTH_URL: http://localhost:8642
+              HERMES_HOME: /opt/data
+              HOME: /opt/data
+              NO_COLOR: "1"
+            args:
+              - dashboard
+              - --host
+              - 0.0.0.0
+              - --insecure
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 50m
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10000
+        runAsGroup: 10000
+        fsGroup: 10000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: hermes
+        ports:
+          http:
+            port: 8642
+      dashboard:
+        controller: hermes
+        ports:
+          http:
+            port: 9119
+    persistence:
+      data:
+        type: emptyDir
+        globalMounts:
+          - path: /opt/data
+      config:
+        type: configMap
+        name: hermes-config
+        globalMounts:
+          - path: /opt/data/config.yaml
+            subPath: config.yaml
+            readOnly: true

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -78,6 +78,17 @@ spec:
         ports:
           http:
             port: 9119
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: dashboard
+                port: http
     persistence:
       data:
         type: emptyDir

--- a/kubernetes/apps/ai/hermes/app/kustomization.yaml
+++ b/kubernetes/apps/ai/hermes/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/ai/hermes/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/hermes/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: hermes
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/ai/hermes/ks.yaml
+++ b/kubernetes/apps/ai/hermes/ks.yaml
@@ -11,6 +11,10 @@ spec:
     - name: konflate-mcp
   interval: 1h
   path: ./kubernetes/apps/ai/hermes/app
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/ai/hermes/ks.yaml
+++ b/kubernetes/apps/ai/hermes/ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: hermes
+spec:
+  dependsOn:
+    - name: toolhive-config
+    - name: context7-mcp
+    - name: konflate-mcp
+  interval: 1h
+  path: ./kubernetes/apps/ai/hermes/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  wait: false

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - ./namespace.yaml
   - ./toolhive/ks.yaml
   - ./mcp
+  - ./hermes/ks.yaml

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -8,6 +8,6 @@ components:
   - ../../components/sops
 resources:
   - ./namespace.yaml
-  - ./toolhive/ks.yaml
-  - ./mcp
   - ./hermes/ks.yaml
+  - ./mcp
+  - ./toolhive/ks.yaml


### PR DESCRIPTION
## Summary

- Deploy Hermes in the `ai` namespace as the first internal AI workbench consumer.
- Wire Hermes to the existing ToolHive vMCP service at `vmcp-home-ops-workbench.ai.svc.cluster.local:4483/mcp`.
- Expose the dashboard on `envoy-internal` at `hermes.${SECRET_DOMAIN}`.
- Keep the MVP intentionally small: gateway + dashboard only, no PVC, no LiteLLM, no Memini, and no code-server.

## Reference shape

This follows the same general Hermes + ToolHive vMCP direction as Jory's workbench, but trims it to the minimum useful slice for this cluster:

- Uses this repo's app-template + Flux Kustomization + ExternalSecret conventions.
- Uses direct MiniMax provider configuration instead of adding LiteLLM.
- Uses ephemeral `emptyDir` state for now; durable state can be added once the workbench proves useful.
- Uses an `envoy-internal` route for the dashboard, matching the peer shape for Hermes access while leaving code-server out of this MVP.

## Operator notes

Before reconciling this, create a 1Password item named `hermes` with a `MINIMAX_API_KEY` field. External Secrets renders that into `hermes-secret`.

After merge, test the dashboard through the internal route at `https://hermes.${SECRET_DOMAIN}`.

## Validation

- `oxfmt --check kubernetes/apps/ai/hermes kubernetes/apps/ai/kustomization.yaml`
- `kustomize build kubernetes/apps/ai/hermes/app`
- `kustomize build kubernetes/apps/ai`
- `flate build hr hermes -n ai -p ./kubernetes/flux/cluster --allow-missing-secrets`
- `flate build hr hermes -n ai -p ./kubernetes/flux/cluster --allow-missing-secrets | kubeconform -strict -summary -ignore-missing-schemas`
- `flate diff all -p ./kubernetes/flux/cluster --base main --allow-missing-secrets --cache-dir /private/tmp/flate-cache -n ai -o human`
- `flate diff images -p ./kubernetes/flux/cluster --base main --allow-missing-secrets --cache-dir /private/tmp/flate-cache`
- `flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets --cache-dir /private/tmp/flate-cache`
- `git diff --check`

`flate test all` has the existing offline warning for `cloudflare-tunnel-id-secret`; Hermes itself renders cleanly. `kubeconform` validates the standard rendered resources and skips the HTTPRoute schema under `-ignore-missing-schemas`.
