### PR TITLE
fix(ai): allow hermes s6 init to start

### DIFF
--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -30,9 +30,6 @@ spec:
               - gateway
               - run
               - --no-supervise
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities: { drop: ["ALL"] }
             resources:
               requests:
                 cpu: 100m
@@ -52,9 +49,6 @@ spec:
               - --host
               - 0.0.0.0
               - --insecure
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities: { drop: ["ALL"] }
             resources:
               requests:
                 cpu: 50m
@@ -62,11 +56,10 @@ spec:
                 memory: 512Mi
     defaultPodOptions:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 10000
-        runAsGroup: 10000
         fsGroup: 10000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
     service:
       app:
         controller: hermes


### PR DESCRIPTION
## Overview

Fix Hermes startup by relaxing the security context that forced the image to start as UID 10000 with all capabilities dropped.

The Hermes image runs s6-overlay during preinit. With the pod forced to non-root, s6 could not fix `/run` ownership/permissions and both the `app` and `dashboard` containers exited before Hermes started.

## Changes

- Remove container-level `securityContext` from the Hermes `app` and `dashboard` containers.
- Remove pod-level `runAsNonRoot`, `runAsUser`, and `runAsGroup`.
- Keep pod-level `fsGroup` and `fsGroupChangePolicy`.
- Add `seccompProfile: RuntimeDefault`.

## Reference

This follows the Jory-style Hermes shape: keep pod filesystem ownership defaults, but do not force the Hermes containers to run as a specific UID before the image entrypoint has initialized. I did not use the more explicit root-plus-capability allow-list pattern because this smaller change lets the image defaults handle s6 startup.

## Validation

- `oxfmt --check kubernetes/apps/ai/hermes/app/helmrelease.yaml`
- `kustomize build kubernetes/apps/ai/hermes/app`
- `flate build hr hermes -n ai -p ./kubernetes/flux/cluster --allow-missing-secrets --cache-dir /private/tmp/flate-cache`
- `kubeconform -strict -summary -ignore-missing-schemas /private/tmp/hermes-render.yaml`
  - 5 resources found: 4 valid, 0 invalid, 0 errors, 1 skipped
- `flate diff all -p ./kubernetes/flux/cluster --base origin/main --allow-missing-secrets --cache-dir /private/tmp/flate-cache -n ai -o human`
  - diff is limited to Hermes source/rendered security context fields
- `flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets --cache-dir /private/tmp/flate-cache -n ai`
  - 12 passed
  - one existing offline substitution warning for `cloudflare-tunnel-id-secret`

## Post-Merge Check

- `kubectl -n ai rollout status deploy/hermes --timeout=3m`
- `kubectl -n ai logs deploy/hermes -c app --tail=80`
- `kubectl -n ai logs deploy/hermes -c dashboard --tail=80`
