### PR TITLE
fix(ai): avoid hermes dashboard log lock contention

### DIFF
--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -41,8 +41,6 @@ spec:
               tag: v2026.6.5@sha256:9ad3b04ec916ea2c2da22358fd43b024c788d74073210695af88bfc2e63869b4
             env:
               GATEWAY_HEALTH_URL: http://localhost:8642
-              HERMES_HOME: /opt/data
-              HOME: /opt/data
               NO_COLOR: "1"
             args:
               - dashboard


### PR DESCRIPTION
## Overview

Fix Hermes dashboard log-lock contention after the gateway and dashboard containers start successfully.

The dashboard was configured with the same `HERMES_HOME=/opt/data` and `HOME=/opt/data` as the gateway. Both containers then tried to use the same s6 log lock under `/opt/data/logs/gateways/default/lock`, causing repeated dashboard log errors:

```text
s6-log: fatal: unable to lock /opt/data/logs/gateways/default/lock: Resource busy
```

## Changes

- Remove `HERMES_HOME` from the dashboard container env.
- Remove `HOME` from the dashboard container env.
- Leave the gateway container env unchanged.

## Reference

- Jory's current Hermes deployment sets `HERMES_HOME`/`HOME` on the gateway container, but not on the dashboard container.
- kubesearch indexed Hermes examples show the same pattern: `controllers.hermes.containers.app.env.HERMES_HOME` is present across the indexed deployments, while dashboard examples expose `GATEWAY_HEALTH_URL`, image, resources, args, and timezone, not dashboard `HERMES_HOME`/`HOME`.

## Validation

- `oxfmt --check kubernetes/apps/ai/hermes/app/helmrelease.yaml`
- `kustomize build kubernetes/apps/ai/hermes/app`
- `flate build hr hermes -n ai -p ./kubernetes/flux/cluster --allow-missing-secrets --cache-dir /private/tmp/flate-cache`
- `kubeconform -strict -summary -ignore-missing-schemas /private/tmp/hermes-dashboard-render.yaml`
  - 5 resources found: 4 valid, 0 invalid, 0 errors, 1 skipped
- `flate diff all -p ./kubernetes/flux/cluster --base origin/main --allow-missing-secrets --cache-dir /private/tmp/flate-cache -n ai -o human`
  - diff is limited to the two dashboard env removals in source and rendered Deployment
- `flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets --cache-dir /private/tmp/flate-cache -n ai`
  - 12 passed
  - one existing offline substitution warning for `cloudflare-tunnel-id-secret`

## Post-Merge Check

- `kubectl -n ai rollout status deploy/hermes --timeout=3m`
- `kubectl -n ai logs deploy/hermes -c dashboard --tail=80`
- `kubectl -n ai logs deploy/hermes -c app --tail=80`
