### PR TITLE
fix(ai): run hermes dashboard in app container

### DIFF
--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -21,6 +21,10 @@ spec:
               tag: v2026.6.5@sha256:9ad3b04ec916ea2c2da22358fd43b024c788d74073210695af88bfc2e63869b4
             env:
               HERMES_HOME: /opt/data
+              HERMES_DASHBOARD: "1"
+              HERMES_DASHBOARD_HOST: 0.0.0.0
+              HERMES_DASHBOARD_INSECURE: "1"
+              HERMES_DASHBOARD_PORT: "9119"
               HOME: /opt/data
               NO_COLOR: "1"
             envFrom:
@@ -35,23 +39,6 @@ spec:
                 cpu: 100m
               limits:
                 memory: 2Gi
-          dashboard:
-            image:
-              repository: docker.io/nousresearch/hermes-agent
-              tag: v2026.6.5@sha256:9ad3b04ec916ea2c2da22358fd43b024c788d74073210695af88bfc2e63869b4
-            env:
-              GATEWAY_HEALTH_URL: http://localhost:8642
-              NO_COLOR: "1"
-            args:
-              - dashboard
-              - --host
-              - 0.0.0.0
-              - --insecure
-            resources:
-              requests:
-                cpu: 50m
-              limits:
-                memory: 512Mi
     defaultPodOptions:
       securityContext:
         fsGroup: 10000


### PR DESCRIPTION
## Overview

Fix the Hermes deployment shape by running the dashboard from the main Hermes app container instead of a second Hermes container.

The previous separate dashboard container still started Hermes s6 services, including `main-hermes`, and fought the app container for the same log lock:

```text
s6-log: fatal: unable to lock /opt/data/logs/gateways/default/lock: Resource busy
```

That means this was not just a dashboard env issue. The separate dashboard container was the wrong runtime shape for this deployment.

## Changes

- Remove the separate `dashboard` container.
- Enable the dashboard in the `app` container with:
  - `HERMES_DASHBOARD=1`
  - `HERMES_DASHBOARD_HOST=0.0.0.0`
  - `HERMES_DASHBOARD_PORT=9119`
  - `HERMES_DASHBOARD_INSECURE=1`
- Keep the existing dashboard Service and route targeting port `9119`.

## Reference

- Jory's deployment uses a separate dashboard container, but with a richer init/persistent setup.
- eleboucher's deployment serves dashboard traffic from the app container on port `9119`.
- kubesearch's indexed Tanguille Hermes example also enables the dashboard in the app container.

Given the live log evidence from this cluster, the single-container dashboard shape is the safer fit here.

## Validation

- `oxfmt --check kubernetes/apps/ai/hermes/app/helmrelease.yaml`
- `kustomize build kubernetes/apps/ai/hermes/app`
- `flate build hr hermes -n ai -p ./kubernetes/flux/cluster --allow-missing-secrets --cache-dir /private/tmp/flate-cache`
  - rendered Deployment has one container: `app`
  - no rendered `dashboard` container
  - `hermes-dashboard` Service still targets port `9119`
- `kubeconform -strict -summary -ignore-missing-schemas /private/tmp/hermes-single-render.yaml`
  - 5 resources found: 4 valid, 0 invalid, 0 errors, 1 skipped
- `flate diff all -p ./kubernetes/flux/cluster --base origin/main --allow-missing-secrets --cache-dir /private/tmp/flate-cache -n ai -o human`
  - diff is limited to removing the dashboard container and adding dashboard env to the app container
- `flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets --cache-dir /private/tmp/flate-cache -n ai`
  - 12 passed
  - one existing offline substitution warning for `cloudflare-tunnel-id-secret`

## Post-Merge Check

- `kubectl -n ai rollout status deploy/hermes --timeout=3m`
- `kubectl -n ai logs deploy/hermes -c app --tail=120`
- Confirm there is no rendered or live `dashboard` container on `deploy/hermes`.
