### PR TITLE
fix(ai): expose toolhive mcp tools to hermes

### DIFF
--- a/kubernetes/apps/ai/hermes/app/configmap.yaml
+++ b/kubernetes/apps/ai/hermes/app/configmap.yaml
@@ -10,6 +10,7 @@ data:
       default: MiniMax-M3
     toolsets:
       - hermes-cli
+      - mcp-toolhive
     terminal:
       backend: local
       cwd: /opt/data/workspace


### PR DESCRIPTION
## Overview

Expose the connected ToolHive MCP server tools to Hermes chat sessions.

Hermes was connecting to the ToolHive MCP endpoint, and the dashboard showed the server/tools, but chat sessions only enabled the `hermes-cli` toolset. Upstream Hermes docs state that each MCP server creates a dynamic runtime toolset named `mcp-<server>`. For this server, that toolset is `mcp-toolhive`.

Without enabling that runtime toolset, the model can report that an MCP server is connected while still not receiving callable `mcp_toolhive_*` tools.

## Changes

- Add `mcp-toolhive` to the Hermes `toolsets` list.

## Expected Result

New Hermes sessions should expose ToolHive MCP tools with names like:

- `mcp_toolhive_context7_query_docs`
- `mcp_toolhive_context7_resolve_library_id`
- `mcp_toolhive_konflate_get_pr_diff`
- `mcp_toolhive_konflate_get_pr_summary`
- `mcp_toolhive_konflate_list_pull_requests`

## Validation

- `oxfmt --check kubernetes/apps/ai/hermes/app/configmap.yaml`
- `kustomize build kubernetes/apps/ai/hermes/app`
- `flate build ks hermes -n ai -p ./kubernetes/flux/cluster --allow-missing-secrets --cache-dir /private/tmp/flate-cache`
- `kubeconform -strict -summary -ignore-missing-schemas /private/tmp/hermes-mcp-toolset-render.yaml`
  - 4 resources found: 1 valid, 0 invalid, 0 errors, 3 skipped
- `flate diff all -p ./kubernetes/flux/cluster --base origin/main --allow-missing-secrets --cache-dir /private/tmp/flate-cache -n ai -o human`
  - diff is limited to the one `mcp-toolhive` line in `hermes-config`
- `flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets --cache-dir /private/tmp/flate-cache -n ai`
  - 12 passed
  - one existing offline substitution warning for `cloudflare-tunnel-id-secret`

## Post-Merge Check

After Flux reconciles and Hermes reloads/restarts, start a new session and ask:

```text
List your available MCP-backed tools. Use exact tool names.
```

Expected: the answer includes `mcp_toolhive_*` tools. If the old session still lacks them, run `/reload-mcp` or restart the Hermes pod and start a fresh session.
