### PR TITLE
feat(ai): add read-only mcp surfaces

### DIFF
--- a/kubernetes/apps/ai/mcp/flux-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/ai/mcp/flux-mcp/app/kustomization.yaml
@@ -3,8 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./context7-mcp/ks.yaml
-  - ./flux-mcp/ks.yaml
-  - ./github-mcp/ks.yaml
-  - ./grafana-mcp/ks.yaml
-  - ./konflate-mcp/ks.yaml
+  - ./mcpserver.yaml
+  - ./rbac.yaml

--- a/kubernetes/apps/ai/mcp/flux-mcp/app/mcpserver.yaml
+++ b/kubernetes/apps/ai/mcp/flux-mcp/app/mcpserver.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1beta1.json
+apiVersion: toolhive.stacklok.dev/v1beta1
+kind: MCPServer
+metadata:
+  name: flux
+spec:
+  image: ghcr.io/controlplaneio-fluxcd/flux-operator-mcp:v0.52.0@sha256:50b6b5f346642591e63e7a70a38e60ed5336163d34966bb63e6fbd709ad8a0dd
+  transport: streamable-http
+  proxyPort: 8080
+  mcpPort: 8000
+  args:
+    - serve
+    - --transport=http
+    - --port=8000
+    - --read-only=true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  serviceAccount: flux-mcp
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          env:
+            - name: RUNTIME_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/apps/ai/mcp/flux-mcp/app/rbac.yaml
+++ b/kubernetes/apps/ai/mcp/flux-mcp/app/rbac.yaml
@@ -1,0 +1,103 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flux-mcp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flux-mcp-readonly
+rules:
+  - apiGroups:
+      - fluxcd.controlplane.io
+      - helm.toolkit.fluxcd.io
+      - image.toolkit.fluxcd.io
+      - kustomize.toolkit.fluxcd.io
+      - notification.toolkit.fluxcd.io
+      - source.toolkit.fluxcd.io
+    resources:
+      - "*"
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - events
+      - namespaces
+      - persistentvolumeclaims
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+      - httproutes
+      - referencegrants
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flux-mcp-readonly
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flux-mcp-readonly
+subjects:
+  - kind: ServiceAccount
+    name: flux-mcp
+    namespace: ai

--- a/kubernetes/apps/ai/mcp/flux-mcp/ks.yaml
+++ b/kubernetes/apps/ai/mcp/flux-mcp/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: flux-mcp
+spec:
+  dependsOn:
+    - name: toolhive-config
+  interval: 1h
+  path: ./kubernetes/apps/ai/mcp/flux-mcp/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  wait: false

--- a/kubernetes/apps/ai/mcp/github-mcp/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/mcp/github-mcp/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: github-mcp
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: github-mcp-secret
+    template:
+      data:
+        Authorization: "Bearer {{ .GITHUB_MCP_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: github-mcp

--- a/kubernetes/apps/ai/mcp/github-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/ai/mcp/github-mcp/app/kustomization.yaml
@@ -3,6 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./context7-mcp/ks.yaml
-  - ./github-mcp/ks.yaml
-  - ./konflate-mcp/ks.yaml
+  - ./externalsecret.yaml
+  - ./mcpserverentry.yaml

--- a/kubernetes/apps/ai/mcp/github-mcp/app/mcpserverentry.yaml
+++ b/kubernetes/apps/ai/mcp/github-mcp/app/mcpserverentry.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserverentry_v1beta1.json
+apiVersion: toolhive.stacklok.dev/v1beta1
+kind: MCPServerEntry
+metadata:
+  name: github
+spec:
+  remoteUrl: https://api.githubcopilot.com/mcp/readonly
+  transport: streamable-http
+  groupRef:
+    name: mcp-tools
+  headerForward:
+    addPlaintextHeaders:
+      X-MCP-Readonly: "true"
+      X-MCP-Toolsets: repos,issues,pull_requests,actions
+    addHeadersFromSecret:
+      - headerName: Authorization
+        valueSecretRef:
+          name: github-mcp-secret
+          key: Authorization

--- a/kubernetes/apps/ai/mcp/github-mcp/app/mcpserverentry.yaml
+++ b/kubernetes/apps/ai/mcp/github-mcp/app/mcpserverentry.yaml
@@ -12,7 +12,7 @@ spec:
   headerForward:
     addPlaintextHeaders:
       X-MCP-Readonly: "true"
-      X-MCP-Toolsets: repos,issues,pull_requests,actions
+      X-MCP-Toolsets: context,repos,issues,pull_requests,actions
     addHeadersFromSecret:
       - headerName: Authorization
         valueSecretRef:

--- a/kubernetes/apps/ai/mcp/github-mcp/ks.yaml
+++ b/kubernetes/apps/ai/mcp/github-mcp/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: github-mcp
+spec:
+  dependsOn:
+    - name: toolhive-config
+  interval: 1h
+  path: ./kubernetes/apps/ai/mcp/github-mcp/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  wait: false

--- a/kubernetes/apps/ai/mcp/grafana-mcp/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/mcp/grafana-mcp/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grafana-mcp
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: grafana-mcp-secret
+    template:
+      data:
+        GRAFANA_SERVICE_ACCOUNT_TOKEN: "{{ .GRAFANA_SERVICE_ACCOUNT_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: grafana-mcp

--- a/kubernetes/apps/ai/mcp/grafana-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/ai/mcp/grafana-mcp/app/kustomization.yaml
@@ -3,8 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./context7-mcp/ks.yaml
-  - ./flux-mcp/ks.yaml
-  - ./github-mcp/ks.yaml
-  - ./grafana-mcp/ks.yaml
-  - ./konflate-mcp/ks.yaml
+  - ./externalsecret.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/mcp/grafana-mcp/app/mcpserver.yaml
+++ b/kubernetes/apps/ai/mcp/grafana-mcp/app/mcpserver.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1beta1.json
+apiVersion: toolhive.stacklok.dev/v1beta1
+kind: MCPServer
+metadata:
+  name: grafana
+spec:
+  image: docker.io/grafana/mcp-grafana:0.15.2@sha256:f7006c42d81e444b77694e4c63c75577a5c45a187088d9799aff23d5e13765cf
+  transport: streamable-http
+  proxyPort: 8080
+  mcpPort: 8000
+  args:
+    - -t
+    - streamable-http
+    - --address
+    - 0.0.0.0:8000
+    - --disable-admin
+    - --disable-incident
+    - --disable-oncall
+    - --disable-provisioning
+    - --disable-rendering
+    - --disable-sift
+    - --disable-write
+  env:
+    - name: GRAFANA_URL
+      value: http://grafana-service.observability.svc.cluster.local:3000
+  secrets:
+    - name: grafana-mcp-secret
+      key: GRAFANA_SERVICE_ACCOUNT_TOKEN
+      targetEnvName: GRAFANA_SERVICE_ACCOUNT_TOKEN
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/apps/ai/mcp/grafana-mcp/ks.yaml
+++ b/kubernetes/apps/ai/mcp/grafana-mcp/ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: grafana-mcp
+spec:
+  dependsOn:
+    - name: toolhive-config
+    - name: grafana-instance
+      namespace: observability
+  interval: 1h
+  path: ./kubernetes/apps/ai/mcp/grafana-mcp/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  wait: false


### PR DESCRIPTION
## Summary

- Add GitHub `context` to the existing read-only GitHub MCP surface.
- Add Flux Operator MCP as a ToolHive `MCPServer` using in-cluster service account auth and read-only RBAC.
- Add Grafana MCP as a ToolHive `MCPServer` pointed at the in-cluster Grafana service with write/admin/incident/oncall/sift/rendering/provisioning tools disabled.

## Reference notes

- Jory runs the same broad MCP categories under ToolHive, but this repo uses the existing `ai/mcp` layout and ToolHive `v1beta1` resources.
- Flux deliberately diverges from Jory by not adding Flux write RBAC. The service account can read Flux objects, related workload state, events, and pod logs, but cannot reconcile, suspend, resume, patch, create, update, or delete.
- Grafana deliberately diverges from Jory by running the official pinned `grafana/mcp-grafana` image directly through ToolHive instead of a separate `mcp/grafana:latest` service. It uses a service account token rather than Grafana admin credentials.

## Runtime setup

Required 1Password items:

- `github-mcp` with `GITHUB_MCP_TOKEN`
- `grafana-mcp` with `GRAFANA_SERVICE_ACCOUNT_TOKEN`

Use a fine-grained, read-only GitHub token limited to `alex-matthews/home-ops` where possible.

For Grafana, create a service account token with only the read/query access needed for dashboards and datasources. Do not reuse the admin password for this MCP surface.

## Validation

```sh
oxfmt --check kubernetes/apps/ai/mcp
kubectl kustomize kubernetes/apps/ai/mcp/flux-mcp/app
kubectl kustomize kubernetes/apps/ai/mcp/grafana-mcp/app
kubectl kustomize kubernetes/apps/ai/mcp
kubectl kustomize kubernetes/apps/ai/mcp/flux-mcp/app | kubeconform -strict -ignore-missing-schemas -schema-location default -schema-location 'https://k8s-schemas.home-operations.com/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
kubectl kustomize kubernetes/apps/ai/mcp/grafana-mcp/app | kubeconform -strict -ignore-missing-schemas -schema-location default -schema-location 'https://k8s-schemas.home-operations.com/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
kubectl kustomize kubernetes/apps/ai/mcp | kubeconform -strict -ignore-missing-schemas -schema-location default -schema-location 'https://k8s-schemas.home-operations.com/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets
```

## Post-merge check

- Verify `ExternalSecret/github-mcp` and `ExternalSecret/grafana-mcp` become Ready.
- Verify `MCPServerEntry/github`, `MCPServer/flux`, and `MCPServer/grafana` become Ready in ToolHive.
- Reload Hermes MCPs and confirm GitHub, Flux, Grafana, Konflate, and Context7 tools appear behind the ToolHive vMCP.
