### PR TITLE
fix(ai): filter grafana mcp tools

### DIFF
--- a/kubernetes/apps/ai/mcp/grafana-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/ai/mcp/grafana-mcp/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./mcpserver.yaml
+  - ./toolconfig.yaml

--- a/kubernetes/apps/ai/mcp/grafana-mcp/app/mcpserver.yaml
+++ b/kubernetes/apps/ai/mcp/grafana-mcp/app/mcpserver.yaml
@@ -35,5 +35,7 @@ spec:
     limits:
       cpu: 250m
       memory: 256Mi
+  toolConfigRef:
+    name: grafana
   groupRef:
     name: mcp-tools

--- a/kubernetes/apps/ai/mcp/grafana-mcp/app/toolconfig.yaml
+++ b/kubernetes/apps/ai/mcp/grafana-mcp/app/toolconfig.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcptoolconfig_v1beta1.json
+apiVersion: toolhive.stacklok.dev/v1beta1
+kind: MCPToolConfig
+metadata:
+  name: grafana
+spec:
+  toolsFilter:
+    - analyze_loki_labels
+    - generate_deeplink
+    - get_annotation_tags
+    - get_annotations
+    - get_dashboard_by_uid
+    - get_dashboard_panel_queries
+    - get_dashboard_property
+    - get_dashboard_summary
+    - get_datasource
+    - list_datasources
+    - list_loki_label_names
+    - list_loki_label_values
+    - list_prometheus_label_names
+    - list_prometheus_label_values
+    - list_prometheus_metric_metadata
+    - list_prometheus_metric_names
+    - query_loki_logs
+    - query_loki_patterns
+    - query_loki_stats
+    - query_prometheus
+    - query_prometheus_histogram
+    - search_dashboards
+    - search_folders
+    - suggest_loki_alloy_label_config


### PR DESCRIPTION
## Summary

- Add a ToolHive `MCPToolConfig` allowlist for the Grafana MCP server.
- Wire `MCPServer/grafana` to that allowlist with `toolConfigRef`.
- Keep dashboard, datasource, Prometheus, Loki, annotation-read, folder search, deeplink, and Loki label-suggestion tools.

## Why

The initial Grafana MCP deployment worked, but upstream defaults exposed more surface than this workbench needs. In particular, the virtual MCP listed broad tools such as `grafana_grafana_api_request` and alerting management tools. `--disable-write` remains in place, but the ToolHive allowlist makes the exposed tool surface deterministic.

Expected removals from Hermes/ToolHive after reconcile:

- `grafana_grafana_api_request`
- `grafana_alerting_manage_rules`
- `grafana_alerting_manage_routing`
- `grafana_get_assertions`
- `grafana_get_plugin`
- `grafana_search_plugin_information`
- Pyroscope tools

## Validation

```sh
oxfmt --check kubernetes/apps/ai/mcp/grafana-mcp
kubectl kustomize kubernetes/apps/ai/mcp/grafana-mcp/app
kubectl kustomize kubernetes/apps/ai/mcp/grafana-mcp/app | kubeconform -strict -ignore-missing-schemas -schema-location default -schema-location 'https://k8s-schemas.home-operations.com/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
kubectl kustomize kubernetes/apps/ai/mcp | kubeconform -strict -ignore-missing-schemas -schema-location default -schema-location 'https://k8s-schemas.home-operations.com/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets
```

## Post-merge check

- Verify `MCPToolConfig/grafana` is reconciled in `ai`.
- Verify `MCPServer/grafana` remains Ready.
- Reload Hermes MCPs and confirm the Grafana tool list no longer includes the broad or management-oriented tools above.
