### PR TITLE
ci: clean up workflow linting

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+---
+self-hosted-runner:
+  labels:
+    - home-ops-runner

--- a/.github/workflows/image-pull.yaml
+++ b/.github/workflows/image-pull.yaml
@@ -47,9 +47,11 @@ jobs:
       - name: Run Flate
         id: flate
         run: |
-          echo 'images<<EOF' >> "$GITHUB_OUTPUT"
-          flate diff images -p ./kubernetes/flux/cluster -o json >> "$GITHUB_OUTPUT"
-          echo 'EOF' >> "$GITHUB_OUTPUT"
+          {
+            echo 'images<<EOF'
+            flate diff images -p ./kubernetes/flux/cluster -o json
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
 
   pull:
     if: >-
@@ -67,8 +69,12 @@ jobs:
       max-parallel: 4
       fail-fast: false
     steps:
-      - name: Install talosctl
-        run: curl -fsSL https://talos.dev/install | sh
+      - name: Setup Mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          cache: false
+          tool_versions: |
+            talosctl latest
 
       - name: Pull image
         env:


### PR DESCRIPTION
## Summary

- add an actionlint config for the home-ops self-hosted runner label
- make Image Pull's Flate output block shellcheck/actionlint clean
- install talosctl with jdx/mise-action instead of curl-piped shell install, matching peer Image Pull workflow shape

## Validation

- git diff --check
- actionlint .github/workflows/*.yaml
- zizmor --offline .github/workflows/*.yaml
- oxfmt --check .github/actionlint.yaml .github/workflows/image-pull.yaml

## Audit notes

Broader workflow policy decisions are intentionally left out of this PR: whether to retire the standalone Flate workflow, prune labels, rename checks/jobs, or simplify the Renovate research reviewer.