### PR TITLE
chore(renovate): group toolhive updates

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -104,6 +104,16 @@
       },
       minimumGroupSize: 2,
     },
+    {
+      description: "ToolHive Group",
+      groupName: "toolhive",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["/toolhive-operator$/", "/toolhive-operator-crds$/"],
+      group: {
+        commitMessageTopic: "{{{groupName}}} group",
+      },
+      minimumGroupSize: 2,
+    },
     // Labeling rules
     {
       matchUpdateTypes: ["major"],


### PR DESCRIPTION
## Summary

- group the ToolHive operator and CRD OCI updates in Renovate
- use the existing grouped-update pattern from Rook-Ceph, Flux Operator, Kubernetes, and ARC groups

## Validation

- npx --yes json5 .renovaterc.json5

## Notes

This should collapse the currently separate toolhive-operator and toolhive-operator-crds PRs into one grouped Renovate PR on the next Renovate run.