### PR TITLE
feat(ai): deploy litellm with dragonfly cache

### DIFF
--- a/.github/workflows/image-pull.yaml
+++ b/.github/workflows/image-pull.yaml
@@ -69,6 +69,11 @@ jobs:
       max-parallel: 4
       fail-fast: false
     steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
       - name: Setup Mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:

--- a/docs/adr/0001-ai-home-ops-workbench.md
+++ b/docs/adr/0001-ai-home-ops-workbench.md
@@ -62,8 +62,8 @@ The current architecture is:
 | MCP gateway             | Use ToolHive to expose approved read-only MCPs through explicit trust boundaries.                                    |
 | Agent clients           | Treat Hermes, future OpenClaw, CI reviewers, and scheduled triage jobs as clients of the same trusted MCP surface.   |
 | Memory                  | Evaluate Memini or a similar shared backend after the workbench is useful.                                           |
-| Model routing           | Deploy LiteLLM only when multiple consumers, provider aliases, metrics, or fallback routing justify it.              |
-| Dragonfly               | Deploy only when real consumers need Redis-compatible cache, session, queue, rate-limit, or memory support.          |
+| Model routing           | Deploy a small internal LiteLLM MVP for provider aliases, metrics, and Redis-backed cache/router coordination.       |
+| Dragonfly               | Deploy Dragonfly-operator with a non-persistent LiteLLM Dragonfly instance; defer durable/shared state until needed. |
 | Backlog source of truth | Use GitHub Issues, optionally GitHub Projects, with ADRs for durable architecture decisions.                         |
 | Community signal        | Prefer GitHub-first peer-repo monitoring and sanctioned digest exports. Do not use Discord scraping.                 |
 
@@ -90,9 +90,9 @@ Cluster
   ├─ Hermes
   ├─ future OpenClaw assistant
   ├─ future scheduled triage workers
-  ├─ future shared memory service
-  ├─ future Dragonfly, if shared state consumers justify it
-  └─ LiteLLM, if provider routing becomes useful enough
+  ├─ LiteLLM, internal-only MVP
+  │    └─ Dragonfly cache/router state
+  └─ future shared memory service
 
 External services
   ├─ GitHub
@@ -141,7 +141,12 @@ LiteLLM is useful only if it earns its place as a small gateway:
 - Prometheus-visible latency, error, and usage metrics;
 - cache or budget controls that do not require PostgreSQL.
 
-Do not deploy LiteLLM solely because peer repositories run it.
+The initial deployment is an internal-only MVP: one LiteLLM replica, no public
+route, no PostgreSQL, and no durable LiteLLM state. Dragonfly is used only as
+non-persistent Redis-compatible cache/router state for LiteLLM. Public access,
+auth frontends, provider budget enforcement, durable spend tracking, and broader
+fallback routing remain separate follow-up decisions. Do not deploy or expand
+LiteLLM solely because peer repositories run it.
 
 ### 4.4 MCP trust boundaries
 
@@ -303,12 +308,12 @@ a self-hosted metasearch endpoint.
 
 ### 5.6 Dragonfly first
 
-Deferred. Dragonfly-operator is a reasonable substrate if the workbench grows
-toward the bjw-s-labs shape, where several AI-adjacent workloads use
-Redis-compatible backing. It should not be deployed only because it is useful in
-theory. It becomes justified when real consumers need cache, session, queue,
-rate-limit, or shared-memory backing, such as SearXNG limiter support,
-Memini/shared memory, LiteLLM cache or coordination, or OpenClaw/Hermes state.
+Partially adopted. Dragonfly-operator is justified by LiteLLM cache/router
+coordination, but the first Dragonfly instance should be non-persistent and
+app-local. Durable Redis-compatible state remains deferred until a consumer needs
+it. Likely future consumers include SearXNG limiter support, Memini/shared
+memory, OpenClaw/Hermes state, or broader LiteLLM routing and rate-limit
+coordination.
 
 ### 5.7 Discord bot or Discord scraping
 
@@ -324,7 +329,11 @@ Implemented:
 2. Deploy Hermes as the interactive workbench surface.
 3. Deploy ToolHive with read-only Context7, GitHub, Konflate, Flux, and Grafana
    MCP surfaces.
-4. Capture starter Hermes prompts in
+4. Deploy LiteLLM as an internal-only model gateway MVP without PostgreSQL or
+   public ingress.
+5. Deploy Dragonfly-operator and a non-persistent LiteLLM Dragonfly instance for
+   Redis-compatible cache/router state.
+6. Capture starter Hermes prompts in
    [`docs/operations/ai-workbench.md`](../operations/ai-workbench.md).
 
 Next:
@@ -334,8 +343,10 @@ Next:
    predictable re-review behavior.
 3. Evaluate shared assistant memory, likely Memini or a similar backend, and
    design retrieval and reranking deliberately.
-4. Add Dragonfly when the first real consumer needs Redis-compatible backing.
-5. Revisit LiteLLM once multiple model consumers or routing/metrics needs exist.
+4. Decide whether LiteLLM should become the default model endpoint for Hermes,
+   Claude Code, future reviewers, or OpenClaw.
+5. Decide when Dragonfly should become a shared/durable state substrate rather
+   than LiteLLM-only cache/router state.
 6. Deploy OpenClaw as an always-on assistant only after the read-only MCP and
    memory stack is sane.
 7. Add peer-repository trend summarisation through GitHub-first ingestion.
@@ -376,19 +387,20 @@ operational model are ready.
 - The first version will be less autonomous than some peer stacks.
 - Community trend monitoring will be weaker than full Discord access unless a
   sanctioned digest export is available.
-- LiteLLM may not be worth its operational cost until there are multiple model
-  consumers.
-- Dragonfly adds another operator and stateful substrate, so it should wait for
-  concrete consumers.
+- LiteLLM adds another model gateway surface, so it should stay internal and
+  minimal until real consumers justify expansion.
+- Dragonfly adds another operator and cluster-scoped RBAC. The first instance is
+  intentionally non-persistent cache/router state rather than a durable database.
 
 ## 9. Deferred / Open Questions
 
 1. Which shared memory backend should Hermes and future agents use, and is a
    reranker required from day one?
-2. Should LiteLLM be deployed before there is a second active model consumer?
+2. Which clients should use LiteLLM first, and should any external route exist?
 3. Should `misospace/pr-reviewer-action` be revisited behind LiteLLM, or should
    the Claude-backed Renovate Research Review remain the primary reviewer?
-4. Which first consumer, if any, justifies Dragonfly-operator?
+4. When should Dragonfly become a durable/shared state substrate instead of
+   LiteLLM-only cache/router state?
 5. What is the minimum safe OpenClaw deployment shape for read-only triage and
    notifications?
 6. Can the existing daily home-ops digest be exposed through a sanctioned

--- a/kubernetes/apps/ai/litellm/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/litellm/app/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: litellm
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: litellm-secret
+    template:
+      data:
+        LITELLM_MASTER_KEY: "{{ .LITELLM_MASTER_KEY }}"
+        MINIMAX_API_KEY: "{{ .MINIMAX_API_KEY }}"
+  dataFrom:
+    - extract:
+        key: litellm

--- a/kubernetes/apps/ai/litellm/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/litellm/app/helmrelease.yaml
@@ -1,0 +1,97 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: litellm
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: litellm
+  interval: 1h
+  values:
+    controllers:
+      litellm:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/berriai/litellm
+              tag: v1.89.2@sha256:713e2a036aecc8f2cb24cdf0bdeffd893b4f37190d4b21eb9e26ac648939c67a
+            args:
+              - --config=/app/config.yaml
+            env:
+              LITELLM_LOG: INFO
+              LITELLM_MODE: PRODUCTION
+              PROXY_BASE_URL: http://litellm.ai.svc.cluster.local:4000
+              REDIS_HOST: litellm-dragonfly
+              REDIS_PORT: "6379"
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 4000
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *port
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  failureThreshold: 30
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 2Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+    serviceMonitor:
+      app:
+        endpoints:
+          - interval: 30s
+            path: /metrics/
+            port: http
+            scrapeTimeout: 10s
+    persistence:
+      config:
+        type: configMap
+        name: "{{ .Release.Name }}-configmap"
+        globalMounts:
+          - path: /app/config.yaml
+            subPath: config.yaml
+            readOnly: true
+      cache:
+        type: emptyDir
+        globalMounts:
+          - path: /app/cache

--- a/kubernetes/apps/ai/litellm/app/kustomization.yaml
+++ b/kubernetes/apps/ai/litellm/app/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+configMapGenerator:
+  - name: litellm-configmap
+    files:
+      - config.yaml=./resources/config.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/ai/litellm/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/litellm/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: litellm
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/ai/litellm/app/resources/config.yaml
+++ b/kubernetes/apps/ai/litellm/app/resources/config.yaml
@@ -1,0 +1,51 @@
+---
+model_list:
+  - model_name: minimax/MiniMax-M3
+    litellm_params:
+      model: minimax/MiniMax-M3
+      api_key: os.environ/MINIMAX_API_KEY
+    model_info:
+      mode: chat
+      max_input_tokens: 1000000
+      supports_function_calling: true
+      supports_prompt_caching: true
+      supports_vision: true
+
+  - model_name: minimax/MiniMax-M2.7
+    litellm_params:
+      model: minimax/MiniMax-M2.7
+      api_key: os.environ/MINIMAX_API_KEY
+    model_info:
+      mode: chat
+      max_input_tokens: 204800
+      supports_function_calling: true
+      supports_prompt_caching: true
+      supports_vision: false
+
+general_settings:
+  health_check_endpoint: /v1/health
+
+router_settings:
+  redis_host: os.environ/REDIS_HOST
+  redis_port: os.environ/REDIS_PORT
+  routing_strategy: simple-shuffle
+
+litellm_settings:
+  callbacks:
+    - prometheus
+  success_callback:
+    - prometheus
+  failure_callback:
+    - prometheus
+  prometheus_adapter: true
+  require_auth_for_metrics_endpoint: false
+  cache: true
+  cache_params:
+    type: redis
+    host: os.environ/REDIS_HOST
+    port: os.environ/REDIS_PORT
+  drop_params: true
+  set_verbose: false
+  telemetry: false
+  request_timeout: 3600
+  num_retries: 1

--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: litellm
+spec:
+  components:
+    - ../../../../components/dragonfly
+  dependsOn:
+    - name: dragonfly-operator
+      namespace: database
+  interval: 1h
+  path: ./kubernetes/apps/ai/litellm/app
+  postBuild:
+    substitute:
+      APP: litellm
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  wait: false

--- a/kubernetes/apps/database/dragonfly-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/database/dragonfly-operator/app/helmrelease.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dragonfly-operator
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: dragonfly-operator
+  interval: 30m
+  values:
+    manager:
+      image:
+        repository: ghcr.io/dragonflydb/operator
+      resources:
+        requests:
+          cpu: 10m
+          memory: 128Mi
+        limits:
+          memory: 256Mi

--- a/kubernetes/apps/database/dragonfly-operator/app/kustomization.yaml
+++ b/kubernetes/apps/database/dragonfly-operator/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/database/dragonfly-operator/app/ocirepository.yaml
+++ b/kubernetes/apps/database/dragonfly-operator/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: dragonfly-operator
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v1.6.1
+  url: oci://ghcr.io/dragonflydb/dragonfly-operator/helm/dragonfly-operator

--- a/kubernetes/apps/database/dragonfly-operator/ks.yaml
+++ b/kubernetes/apps/database/dragonfly-operator/ks.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: dragonfly-operator
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/database/dragonfly-operator/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: database
+  wait: true

--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -2,13 +2,9 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: ai
+namespace: database
 components:
   - ../../components/alerts
-  - ../../components/sops
 resources:
   - ./namespace.yaml
-  - ./hermes/ks.yaml
-  - ./litellm/ks.yaml
-  - ./mcp
-  - ./toolhive/ks.yaml
+  - ./dragonfly-operator/ks.yaml

--- a/kubernetes/apps/database/namespace.yaml
+++ b/kubernetes/apps/database/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/components/dragonfly/cluster.yaml
+++ b/kubernetes/components/dragonfly/cluster.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/dragonflydb.io/dragonfly_v1alpha1.json
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  name: ${APP}-dragonfly
+spec:
+  image: ghcr.io/dragonflydb/dragonfly:v1.39.0@sha256:0fa01a2b929e704c7a9300d23e7f52002ebd39e90996fb8bb63826aed92fa06f
+  replicas: ${DRAGONFLY_REPLICAS:=1}
+  env:
+    - name: MAX_MEMORY
+      valueFrom:
+        resourceFieldRef:
+          resource: limits.memory
+          divisor: 1Mi
+  args:
+    - --maxmemory=$(MAX_MEMORY)Mi
+    - --proactor_threads=2
+    - --cluster_mode=emulated
+  resources:
+    requests:
+      cpu: 25m
+    limits:
+      memory: 768Mi

--- a/kubernetes/components/dragonfly/kustomization.yaml
+++ b/kubernetes/components/dragonfly/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/component
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./cluster.yaml


### PR DESCRIPTION
## Summary

- deploy LiteLLM as an internal-only model gateway MVP in the `ai` namespace
- deploy Dragonfly operator in a new `database` namespace and add a reusable `components/dragonfly` cache component
- wire LiteLLM to a non-persistent `litellm-dragonfly` instance for Redis-backed cache/router state
- expose only a ClusterIP LiteLLM service on port 4000 and a ServiceMonitor; no HTTPRoute, PVC, Postgres, or public hostname
- configure MiniMax M3 and M2.7 model aliases using a 1Password-backed ExternalSecret
- update ADR-0001 to reflect the LiteLLM + Dragonfly MVP and keep durable state, auth, and external routing deferred
- fix the Image Pull workflow's mise setup path by checking out the repo before installing repo-pinned `talosctl`

## Pre-Merge Requirement

The backing secret store item must supply `LITELLM_MASTER_KEY` and
`MINIMAX_API_KEY`. Without it, External Secrets will not create
`litellm-secret` and the deployment will not become Ready.

## Exposure And State Posture

LiteLLM is intentionally not exposed through Envoy. The only configured endpoint is the cluster-internal service:

- `http://litellm.ai.svc.cluster.local:4000`

Dragonfly is cache/router state only:

- `litellm-dragonfly` is a Dragonfly CR in the `ai` namespace
- no Dragonfly PVC is rendered
- Dragonfly restart loss is acceptable for this MVP
- durable spend tracking, Postgres, external auth, rate limiting, CrowdSec, Pocket ID/Kanidm, kguardian/network-policy, and public/private HTTPRoute choices remain explicit follow-up decisions

The Dragonfly operator chart renders cluster-scoped RBAC. That is expected for the operator, but it is the main new blast-radius item in this PR.

## Validation

- `gh api repos/BerriAI/litellm/releases/latest --jq '{tag_name, published_at, name}'` confirmed `v1.89.2` as the latest upstream release at implementation time
- `gh api repos/dragonflydb/dragonfly-operator/releases/latest --jq '{tag_name, published_at, name}'` confirmed `v1.6.1` as the latest Dragonfly operator release at implementation time
- `docker buildx imagetools inspect ghcr.io/berriai/litellm:v1.89.2` resolved digest `sha256:713e2a036aecc8f2cb24cdf0bdeffd893b4f37190d4b21eb9e26ac648939c67a`
- `docker buildx imagetools inspect ghcr.io/dragonflydb/dragonfly:v1.39.0` resolved digest `sha256:0fa01a2b929e704c7a9300d23e7f52002ebd39e90996fb8bb63826aed92fa06f`
- `mise exec -- kubectl kustomize kubernetes/apps/ai/litellm/app`
- `mise exec -- kubectl kustomize kubernetes/apps/database`
- `mise exec -- kubectl kustomize kubernetes/apps/database/dragonfly-operator/app`
- `mise exec -- oxfmt --check docs/adr/0001-ai-home-ops-workbench.md kubernetes/apps/database/kustomization.yaml kubernetes/apps/database/namespace.yaml kubernetes/apps/database/dragonfly-operator/ks.yaml kubernetes/apps/database/dragonfly-operator/app/kustomization.yaml kubernetes/apps/database/dragonfly-operator/app/ocirepository.yaml kubernetes/apps/database/dragonfly-operator/app/helmrelease.yaml kubernetes/components/dragonfly/kustomization.yaml kubernetes/components/dragonfly/cluster.yaml kubernetes/apps/ai/litellm/ks.yaml kubernetes/apps/ai/litellm/app/helmrelease.yaml kubernetes/apps/ai/litellm/app/resources/config.yaml`
- `mise exec -- flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets` passed, with only the existing offline `cloudflare-tunnel-id-secret` warning
- `mise exec -- flate diff all -p ./kubernetes/flux/cluster --allow-missing-secrets -o human` showed `ai/litellm-dragonfly`, Dragonfly operator resources, and LiteLLM Redis config/env changes
- targeted rendered checks found no LiteLLM HTTPRoute and no Dragonfly PVC
- `mise exec -- actionlint .github/workflows/image-pull.yaml .github/workflows/flate.yaml .github/workflows/renovate-review.yaml`
- `mise exec -- zizmor --offline .github/workflows/image-pull.yaml`

