### PR TITLE
fix: harden rook alert and workflow tool pins

### DIFF
--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -39,12 +39,15 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install Flate
-        uses: home-operations/flate/action@dfa3992ed14feb4b04df25fe3397606345f87374 # v0.4.7
+      - name: Setup Mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          cache: false
+          install_args: github:home-operations/flate
 
       - name: Run Flate
         id: flate
-        run: flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets
+        run: mise exec -- flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets
 
   success:
     if: ${{ !cancelled() }}

--- a/.github/workflows/image-pull.yaml
+++ b/.github/workflows/image-pull.yaml
@@ -41,15 +41,18 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install Flate
-        uses: home-operations/flate/action@dfa3992ed14feb4b04df25fe3397606345f87374 # v0.4.7
+      - name: Setup Mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          cache: false
+          install_args: github:home-operations/flate
 
       - name: Run Flate
         id: flate
         run: |
           {
             echo 'images<<EOF'
-            flate diff images -p ./kubernetes/flux/cluster -o json
+            mise exec -- flate diff images -p ./kubernetes/flux/cluster -o json
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
@@ -83,7 +86,7 @@ jobs:
       - name: Pull image
         env:
           IMAGE: ${{ matrix.image }}
-        run: talosctl --nodes "${NODE}" image pull "${IMAGE}"
+        run: mise exec -- talosctl --nodes "${NODE}" image pull "${IMAGE}"
 
   success:
     if: ${{ !cancelled() }}

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -13,6 +13,11 @@ spec:
     monitoring:
       enabled: true
       createPrometheusRules: true
+      prometheusRuleOverrides:
+        CephPoolGrowthWarning:
+          expr: >-
+            (max by (cluster, pool_id, instance) (predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5))
+            * on(cluster,pool_id, instance) group_right() ceph_pool_metadata) >= 95
     toolbox:
       enabled: true
     route:


### PR DESCRIPTION
## Summary

- Override only the Rook `CephPoolGrowthWarning` expression so two-day `ceph_pool_percent_used` history is collapsed before joining `ceph_pool_metadata`, preserving the alert while avoiding many-to-many evaluation failures after mgr rollouts.
- Make Flate and Image Pull workflows consume repo-pinned mise tools instead of a separate Flate action pin or ambient shim resolution.
- Run CI tool calls through `mise exec -- flate ...` and `mise exec -- talosctl ...`.

## Validation

- `mise exec -- actionlint .github/workflows/flate.yaml .github/workflows/image-pull.yaml`
- `mise exec -- zizmor --offline .github/workflows/flate.yaml .github/workflows/image-pull.yaml`
- `mise exec -- oxfmt --check .github/workflows/flate.yaml .github/workflows/image-pull.yaml kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml`
- `mise exec -- flate diff all -p ./kubernetes/flux/cluster --allow-missing-secrets -o brief` → 2 changed documents: source HelmRelease and rendered PrometheusRule
- `mise exec -- flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets` → 188 passed; existing offline `cloudflare-tunnel-id-secret` substitution warning only