### PR TITLE
fix(ci): tolerate reviewer marker drift

### DIFF
--- a/.github/workflows/renovate-review.yaml
+++ b/.github/workflows/renovate-review.yaml
@@ -474,31 +474,51 @@ jobs:
           PR: ${{ env.PR_NUMBER }}
           REVIEW_STARTED_AT: ${{ steps.review.outputs.started_at }}
         run: |
-          marker="<!-- home-ops-renovate-research fingerprint:${FINGERPRINT} -->"
+          base_marker="<!-- home-ops-renovate-research -->"
+          fingerprint_marker="<!-- home-ops-renovate-research fingerprint:${FINGERPRINT} -->"
           expected_author="claude[bot]"
           reviews_json="${RUNNER_TEMP}/renovate-research-reviews.json"
+          review=""
 
-          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}/reviews" > "${reviews_json}"
+          for attempt in 1 2 3 4 5 6; do
+            gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR}/reviews" > "${reviews_json}"
 
-          review="$(
-            jq --arg marker "${marker}" --arg started "${REVIEW_STARTED_AT}" '
-                [
-                  .[]
-                  | select(.body != null and (.body | contains($marker)))
-                  | select(.submitted_at >= $started)
-                ]
-                | last // empty
-              ' "${reviews_json}"
-          )"
+            review="$(
+              jq \
+                --arg author "${expected_author}" \
+                --arg head "${HEAD_SHA}" \
+                --arg marker "${base_marker}" \
+                --arg started "${REVIEW_STARTED_AT}" '
+                  [
+                    .[]
+                    | select(.user.login == $author)
+                    | select(.commit_id == $head)
+                    | select(.body != null and (.body | contains($marker)))
+                    | select(.submitted_at >= $started)
+                  ]
+                  | last // empty
+                ' "${reviews_json}"
+            )"
+
+            if [ -n "${review}" ]; then
+              break
+            fi
+
+            if [ "${attempt}" -lt 6 ]; then
+              echo "::notice::Fresh Renovate research review not visible yet; retrying (${attempt}/6)"
+              sleep 5
+            fi
+          done
 
           if [ -z "${review}" ]; then
-            echo "::error::Claude did not submit a fresh Renovate research review with marker ${marker}"
+            echo "::error::Claude did not submit a fresh Renovate research review from ${expected_author} on ${HEAD_SHA} with marker ${base_marker}"
             exit 1
           fi
 
           review_author="$(jq -r '.user.login' <<< "${review}")"
           review_commit="$(jq -r '.commit_id' <<< "${review}")"
           review_submitted_at="$(jq -r '.submitted_at' <<< "${review}")"
+          review_body="$(jq -r '.body // ""' <<< "${review}")"
 
           if [ "${review_author}" != "${expected_author}" ]; then
             echo "::error::Fresh review was authored by ${review_author}; expected ${expected_author}"
@@ -508,6 +528,10 @@ jobs:
           if [ "${review_commit}" != "${HEAD_SHA}" ]; then
             echo "::error::Fresh review is attached to ${review_commit}; expected current PR head ${HEAD_SHA}"
             exit 1
+          fi
+
+          if [[ "${review_body}" != *"${fingerprint_marker}"* ]]; then
+            echo "::notice::Fresh review did not contain the exact fingerprint marker ${fingerprint_marker}; accepting the stable marker on the current head"
           fi
 
           echo "Verified fresh Renovate research review from ${review_author} at ${review_submitted_at} for ${review_commit}."


### PR DESCRIPTION
## Summary

- Make the Renovate Research Review verifier look for a fresh `claude[bot]` PR review on the current head with the stable `home-ops-renovate-research` marker.
- Keep the exact fingerprint marker as a traceability check, but downgrade a missing/mistyped fingerprint marker to a notice instead of failing the workflow.
- Retry the PR reviews API lookup briefly before failing, to avoid GitHub visibility lag immediately after Claude submits a review.

## Context

Run 27808552427 for PR #1330 failed after Claude exited successfully. Claude did submit a fresh review on the current head, but the fingerprint marker in the review body had a one-character typo, so the exact marker check failed.

This keeps author/head/freshness checks strict while avoiding a false negative when the prose model copies the fingerprint imperfectly.

## Validation

- `mise exec -- actionlint .github/workflows/renovate-review.yaml`
- `mise exec -- zizmor --offline .github/workflows/renovate-review.yaml`
- `mise exec -- oxfmt --check .github/workflows/renovate-review.yaml`
- Replayed the #1330 condition against live PR review data: current-head Claude review count is 1; exact fingerprint marker match is false, which now produces a notice instead of failure.