### PR TITLE
fix(ci): run manual reviewer labels from default branch

### DIFF
--- a/.github/workflows/renovate-review.yaml
+++ b/.github/workflows/renovate-review.yaml
@@ -8,9 +8,11 @@ on:
       - opened
       - synchronize
       - reopened
-      - labeled
     branches:
       - main
+  issues:
+    types:
+      - labeled
   workflow_dispatch:
     inputs:
       pr:
@@ -19,11 +21,11 @@ on:
         type: number
 
 env:
-  MANUAL_REVIEW: ${{ github.event_name == 'workflow_dispatch' || (github.event.action == 'labeled' && github.event.label.name == 'renovate-review') }}
-  PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr }}
+  MANUAL_REVIEW: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'renovate-review') }}
+  PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr || github.ref }}${{ github.event.action == 'labeled' && format('-label-{0}', github.run_id) || '' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr || github.ref }}${{ github.event.action == 'labeled' && format('-label-{0}', github.run_id) || '' }}
   cancel-in-progress: true
 
 permissions:
@@ -42,11 +44,13 @@ jobs:
         github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
         github.event.pull_request.user.login == 'bot-ler[bot]' &&
-        !github.event.pull_request.draft &&
-        (
-          github.event.action != 'labeled' ||
-          github.event.label.name == 'renovate-review'
-        )
+        !github.event.pull_request.draft
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'renovate-review' &&
+        github.event.issue.pull_request
       )
     name: Renovate Research Review
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Remove `pull_request.labeled` from Renovate Research Review.
- Add `issues.labeled` for the existing `renovate-review` label so manual re-review labels run from the default-branch workflow.
- Keep normal automatic Renovate reviews on `pull_request` opened/synchronize/reopened.

## Context

Adding `renovate-review` to #1330 produced a new failed run because the `pull_request.labeled` event still executed against stale PR workflow/base state. Claude Code Action rejected the run with:

> Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch.

Using `issues.labeled` should make label-triggered manual reviews use the workflow from `main`, which is the behavior we want for stale Renovate branches.

## Validation

- `mise exec -- actionlint .github/workflows/renovate-review.yaml`
- `mise exec -- zizmor --offline .github/workflows/renovate-review.yaml`
- `mise exec -- oxfmt --check .github/workflows/renovate-review.yaml`