### PR TITLE
fix(ci): run reviewer labels from target workflow

### DIFF
--- a/.github/workflows/renovate-review.yaml
+++ b/.github/workflows/renovate-review.yaml
@@ -10,9 +10,14 @@ on:
       - reopened
     branches:
       - main
-  issues:
+  # zizmor: ignore[dangerous-triggers]
+  # Manual labels must run from the default-branch workflow; the job is limited
+  # to same-repo bot-ler Renovate PRs before checkout.
+  pull_request_target:
     types:
       - labeled
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       pr:
@@ -21,11 +26,11 @@ on:
         type: number
 
 env:
-  MANUAL_REVIEW: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'renovate-review') }}
-  PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr }}
+  MANUAL_REVIEW: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'renovate-review') }}
+  PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr || github.ref }}${{ github.event.action == 'labeled' && format('-label-{0}', github.run_id) || '' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr || github.ref }}${{ github.event.action == 'labeled' && format('-label-{0}', github.run_id) || '' }}
   cancel-in-progress: true
 
 permissions:
@@ -47,10 +52,12 @@ jobs:
         !github.event.pull_request.draft
       ) ||
       (
-        github.event_name == 'issues' &&
+        github.event_name == 'pull_request_target' &&
         github.event.action == 'labeled' &&
         github.event.label.name == 'renovate-review' &&
-        github.event.issue.pull_request
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.user.login == 'bot-ler[bot]' &&
+        !github.event.pull_request.draft
       )
     name: Renovate Research Review
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- switch the manual `renovate-review` label trigger from `issues.labeled` to `pull_request_target.labeled` so stale Renovate branches use the default-branch workflow
- keep the label trigger limited to same-repository, non-draft `bot-ler[bot]` Renovate PRs before checkout
- document the intentional `pull_request_target` use for zizmor

## Validation

- `mise exec -- actionlint .github/workflows/renovate-review.yaml`
- `mise exec -- zizmor --offline .github/workflows/renovate-review.yaml`
- `mise exec -- oxfmt --check .github/workflows/renovate-review.yaml`

## Notes

This is specifically for the stale-branch failure mode where `pull_request.labeled` executes old workflow content and Claude token validation fails before a review can run.