### PR TITLE
fix(ci): dispatch renovate reviews from label trigger

### DIFF
--- a/.github/workflows/renovate-review-trigger.yaml
+++ b/.github/workflows/renovate-review-trigger.yaml
@@ -1,0 +1,100 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Renovate Review Trigger
+
+on:
+  # zizmor: ignore[dangerous-triggers]
+  # This workflow does not checkout or execute PR content. It only dispatches
+  # the default-branch reviewer workflow for same-repo Renovate PRs.
+  pull_request_target:
+    types:
+      - labeled
+    branches:
+      - main
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  dispatch-review:
+    if: >-
+      github.event.label.name == 'renovate-review' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !github.event.pull_request.draft
+    name: Renovate Review Trigger
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check PR eligibility
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          pr_json="$(
+            gh pr view "${PR}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --json author,baseRefName,headRepository,isDraft,state
+          )"
+
+          author="$(jq -r '.author.login' <<< "${pr_json}")"
+          base_ref="$(jq -r '.baseRefName' <<< "${pr_json}")"
+          head_repo="$(jq -r '.headRepository.nameWithOwner' <<< "${pr_json}")"
+          is_draft="$(jq -r '.isDraft' <<< "${pr_json}")"
+          state="$(jq -r '.state' <<< "${pr_json}")"
+
+          if [ "${state}" != "OPEN" ]; then
+            echo "::notice::Skipping Renovate review dispatch; PR #${PR} is ${state}"
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${base_ref}" != "main" ]; then
+            echo "::notice::Skipping Renovate review dispatch; PR #${PR} targets ${base_ref}"
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${head_repo}" != "${GITHUB_REPOSITORY}" ]; then
+            echo "::notice::Skipping Renovate review dispatch; PR #${PR} is from ${head_repo}"
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${author}" != "bot-ler[bot]" ] && [ "${author}" != "app/bot-ler" ]; then
+            echo "::notice::Skipping Renovate review dispatch; PR #${PR} author is ${author}"
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${is_draft}" = "true" ]; then
+            echo "::notice::Skipping Renovate review dispatch; PR #${PR} is a draft"
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "eligible=true" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch Renovate review
+        if: ${{ steps.pr.outputs.eligible == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          gh workflow run renovate-review.yaml \
+            --repo "${GITHUB_REPOSITORY}" \
+            --ref main \
+            -f "pr=${PR}"
+
+      - name: Remove trigger label
+        if: ${{ always() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr edit "${PR}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --remove-label renovate-review

--- a/.github/workflows/renovate-review.yaml
+++ b/.github/workflows/renovate-review.yaml
@@ -10,14 +10,6 @@ on:
       - reopened
     branches:
       - main
-  # zizmor: ignore[dangerous-triggers]
-  # Manual labels must run from the default-branch workflow; the job is limited
-  # to same-repo bot-ler Renovate PRs before checkout.
-  pull_request_target:
-    types:
-      - labeled
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       pr:
@@ -26,11 +18,11 @@ on:
         type: number
 
 env:
-  MANUAL_REVIEW: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'renovate-review') }}
+  MANUAL_REVIEW: ${{ github.event_name == 'workflow_dispatch' }}
   PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr || github.ref }}${{ github.event.action == 'labeled' && format('-label-{0}', github.run_id) || '' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -47,14 +39,6 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event.pull_request.user.login == 'bot-ler[bot]' &&
-        !github.event.pull_request.draft
-      ) ||
-      (
-        github.event_name == 'pull_request_target' &&
-        github.event.action == 'labeled' &&
-        github.event.label.name == 'renovate-review' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
         github.event.pull_request.user.login == 'bot-ler[bot]' &&
         !github.event.pull_request.draft


### PR DESCRIPTION
## Summary

- remove the failed direct `pull_request_target` path from `renovate-review.yaml`
- add a small `Renovate Review Trigger` workflow for the `renovate-review` label
- have the trigger dispatch the supported `workflow_dispatch` path on `main`, then remove the label so it can be reused

## Why

Direct label events for `anthropics/claude-code-action` are brittle here:

- stale Renovate branches run old `pull_request.labeled` workflow content and fail Claude workflow validation
- direct `pull_request_target.labeled` reached the default workflow but failed Claude app-token exchange with `Invalid OIDC token`

This keeps the label UX while keeping Claude itself on the supported `workflow_dispatch` path, so review comments should still be posted by `claude[bot]`.

## Validation

- `mise exec -- actionlint .github/workflows/renovate-review.yaml .github/workflows/renovate-review-trigger.yaml`
- `mise exec -- zizmor --offline .github/workflows/renovate-review.yaml .github/workflows/renovate-review-trigger.yaml`
- `mise exec -- oxfmt --check .github/workflows/renovate-review.yaml .github/workflows/renovate-review-trigger.yaml`