### PR TITLE
fix(ci): allow dispatched renovate reviewer

### DIFF
--- a/.github/workflows/renovate-review-trigger.yaml
+++ b/.github/workflows/renovate-review-trigger.yaml
@@ -16,7 +16,7 @@ permissions:
   actions: write
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   dispatch-review:
@@ -95,6 +95,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
         run: |
-          gh pr edit "${PR}" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --remove-label renovate-review
+          if ! gh api \
+            --method DELETE \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR}/labels/renovate-review"; then
+            echo "::notice::Could not remove renovate-review label automatically"
+          fi

--- a/.github/workflows/renovate-review.yaml
+++ b/.github/workflows/renovate-review.yaml
@@ -219,7 +219,7 @@ jobs:
           PR: ${{ env.PR_NUMBER }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: "bot-ler[bot]"
+          allowed_bots: "bot-ler[bot],github-actions[bot]"
           claude_args: |
             --model ${{ vars.CLAUDE_RENOVATE_REVIEW_MODEL || 'claude-sonnet-4-6' }}
             --allowedTools "Read,Glob,Grep,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr review:*),Bash(gh api:*),Bash(gh release view:*),Bash(gh release list:*),Bash(git log:*),Bash(git diff:*),Bash(curl:*),WebFetch,WebSearch"


### PR DESCRIPTION
## Summary

- allow `github-actions[bot]` to run the Claude action when RRR is launched by the label dispatcher
- grant the trigger workflow PR write permission for label cleanup
- remove the `renovate-review` label through the REST issue-label endpoint and make cleanup non-fatal

## Why

Live testing #1330 showed the dispatcher created the desired `workflow_dispatch` RRR run on `main`, but Claude blocked it because the initiating actor was `github-actions[bot]`. The same test showed GraphQL label removal failed with `Resource not accessible by integration`, so cleanup now uses the issue-label REST endpoint and no longer turns a successful dispatch into a failed trigger.

## Validation

- `mise exec -- actionlint .github/workflows/renovate-review.yaml .github/workflows/renovate-review-trigger.yaml`
- `mise exec -- zizmor --offline .github/workflows/renovate-review.yaml .github/workflows/renovate-review-trigger.yaml`
- `mise exec -- oxfmt --check .github/workflows/renovate-review.yaml .github/workflows/renovate-review-trigger.yaml`