### PR TITLE
feat(ai): route Hermes through LiteLLM

### DIFF
--- a/docs/adr/0001-ai-home-ops-workbench.md
+++ b/docs/adr/0001-ai-home-ops-workbench.md
@@ -333,7 +333,9 @@ Implemented:
    public ingress.
 5. Deploy Dragonfly-operator and a non-persistent LiteLLM Dragonfly instance for
    Redis-compatible cache/router state.
-6. Capture starter Hermes prompts in
+6. Route Hermes through the internal LiteLLM gateway as the first model
+   consumer.
+7. Capture starter Hermes prompts in
    [`docs/operations/ai-workbench.md`](../operations/ai-workbench.md).
 
 Next:
@@ -343,8 +345,8 @@ Next:
    predictable re-review behavior.
 3. Evaluate shared assistant memory, likely Memini or a similar backend, and
    design retrieval and reranking deliberately.
-4. Decide whether LiteLLM should become the default model endpoint for Hermes,
-   Claude Code, future reviewers, or OpenClaw.
+4. Decide whether Claude Code, future reviewers, or OpenClaw should also use
+   LiteLLM.
 5. Decide when Dragonfly should become a shared/durable state substrate rather
    than LiteLLM-only cache/router state.
 6. Deploy OpenClaw as an always-on assistant only after the read-only MCP and
@@ -396,7 +398,8 @@ operational model are ready.
 
 1. Which shared memory backend should Hermes and future agents use, and is a
    reranker required from day one?
-2. Which clients should use LiteLLM first, and should any external route exist?
+2. Which additional clients should use LiteLLM, and should any external route
+   exist?
 3. Should `misospace/pr-reviewer-action` be revisited behind LiteLLM, or should
    the Claude-backed Renovate Research Review remain the primary reviewer?
 4. When should Dragonfly become a durable/shared state substrate instead of

--- a/kubernetes/apps/ai/hermes/app/configmap.yaml
+++ b/kubernetes/apps/ai/hermes/app/configmap.yaml
@@ -5,9 +5,15 @@ metadata:
   name: hermes-config
 data:
   config.yaml: |
+    custom_providers:
+      - name: litellm
+        base_url: http://litellm.ai.svc.cluster.local:4000/v1
+        key_env: LITELLM_MASTER_KEY
+        api_mode: chat_completions
+        model: minimax/MiniMax-M3
     model:
-      provider: minimax
-      default: MiniMax-M3
+      provider: custom:litellm
+      default: minimax/MiniMax-M3
     toolsets:
       - hermes-cli
       - mcp-toolhive

--- a/kubernetes/apps/ai/hermes/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hermes/app/externalsecret.yaml
@@ -12,7 +12,13 @@ spec:
     name: hermes-secret
     template:
       data:
+        LITELLM_MASTER_KEY: "{{ .LITELLM_MASTER_KEY }}"
         MINIMAX_API_KEY: "{{ .MINIMAX_API_KEY }}"
+  data:
+    - secretKey: LITELLM_MASTER_KEY
+      remoteRef:
+        key: litellm
+        property: LITELLM_MASTER_KEY
   dataFrom:
     - extract:
         key: hermes

--- a/kubernetes/apps/ai/hermes/ks.yaml
+++ b/kubernetes/apps/ai/hermes/ks.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   dependsOn:
     - name: toolhive-config
+    - name: litellm
     - name: context7-mcp
     - name: konflate-mcp
   interval: 1h


### PR DESCRIPTION
## Summary

Route Hermes through the internal LiteLLM gateway instead of talking to MiniMax directly.

- Add a named Hermes `custom:litellm` provider using the internal LiteLLM service.
- Source `LITELLM_MASTER_KEY` into `hermes-secret` from the existing `litellm` 1Password item.
- Add a Flux dependency from Hermes to LiteLLM so the model gateway is applied first.
- Update ADR 0001 to record Hermes as the first LiteLLM consumer.

This keeps LiteLLM internal-only: no new HTTPRoute, public endpoint, operator, storage class, or auth surface.

## Validation

- `mise exec -- kubectl kustomize kubernetes/apps/ai/hermes/app`
- `mise exec -- oxfmt --check kubernetes/apps/ai/hermes/app/configmap.yaml kubernetes/apps/ai/hermes/app/externalsecret.yaml kubernetes/apps/ai/hermes/ks.yaml docs/adr/0001-ai-home-ops-workbench.md`
- `mise exec -- flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets`
- `mise exec -- flate diff images -p ./kubernetes/flux/cluster -o json`
- In-pod Hermes runtime smoke with a dummy `LITELLM_MASTER_KEY` confirmed `custom:litellm` resolves to the internal LiteLLM `/v1` endpoint with `chat_completions` transport.

## Rollout notes

After merge, restart or reconcile Hermes and confirm a new dashboard session reports the LiteLLM-backed custom provider. If model calls fail, check `hermes-secret` contains `LITELLM_MASTER_KEY` and that LiteLLM still serves `minimax/MiniMax-M3`.
