### PR TITLE
feat(ai): expose ToolHive internally

### DIFF
--- a/docs/operations/ai-workbench.md
+++ b/docs/operations/ai-workbench.md
@@ -13,6 +13,9 @@ repository docs.
 
 - The current ToolHive workbench surface is read-only by default and is intended
   for Context7, GitHub, Konflate, Flux, and Grafana evidence.
+- The internal ToolHive route is for trusted LAN or WireGuard clients such as
+  Hermes and Codex. Do not expose it through `envoy-external` without a separate
+  authentication decision.
 - Prefer summary tools first. Drill into broad resource lists only after the
   summary shows a problem.
 - Ask for evidence from the named MCP surface rather than accepting a generic
@@ -30,6 +33,22 @@ restart the Hermes gateway from the UI, then run:
 ```text
 /reload-mcp now
 ```
+
+## Codex MCP Access
+
+Codex can consume the same ToolHive vMCP surface through the internal route:
+
+```sh
+codex mcp add toolhive --url "https://toolhive.${SECRET_DOMAIN}/mcp"
+```
+
+Keep local Codex MCP configuration, OAuth state, and bearer tokens out of this
+repository. If Codex is not on the trusted internal network, use a temporary
+`kubectl port-forward` instead of adding a public route.
+
+The current route is an internal-only bridge for stress-testing the workbench
+surface. Before exposing ToolHive more broadly, switch the vMCP to ToolHive
+native OIDC or an equivalent explicit auth boundary.
 
 ## Flux Health
 

--- a/kubernetes/apps/ai/toolhive/config/httproute.yaml
+++ b/kubernetes/apps/ai/toolhive/config/httproute.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: home-ops-workbench
+  annotations:
+    gatus.home-operations.com/enabled: "false"
+spec:
+  hostnames:
+    - toolhive.${SECRET_DOMAIN}
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  rules:
+    - backendRefs:
+        - name: vmcp-home-ops-workbench
+          port: 4483
+      matches:
+        - path:
+            type: PathPrefix
+            value: /mcp

--- a/kubernetes/apps/ai/toolhive/config/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/config/kustomization.yaml
@@ -3,5 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./httproute.yaml
   - ./mcpgroup.yaml
   - ./virtualmcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/ks.yaml
+++ b/kubernetes/apps/ai/toolhive/ks.yaml
@@ -43,6 +43,10 @@ spec:
     - name: toolhive-operator
   interval: 1h
   path: ./kubernetes/apps/ai/toolhive/config
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## Summary

- add an internal Envoy `HTTPRoute` for the ToolHive home-ops vMCP service
- wire `toolhive-config` through `cluster-secrets` substitution for the route hostname
- document Codex MCP access and the boundary that broader exposure needs explicit auth, preferably ToolHive-native OIDC

## Reference posture

- follows the simple internal vMCP route shape seen in bjw-s-labs and m00nwtchr-style workbench deployments
- keeps eleboucher/jfroy-style OIDC MCP auth as the next hardening step rather than mixing IdP rollout into this route change
- disables Gatus discovery for the MCP route to avoid misleading endpoint probes

## Validation

- `mise exec -- oxfmt --check kubernetes/apps/ai/toolhive/config/httproute.yaml kubernetes/apps/ai/toolhive/config/kustomization.yaml kubernetes/apps/ai/toolhive/ks.yaml docs/operations/ai-workbench.md`
- `mise exec -- kubectl kustomize kubernetes/apps/ai/toolhive/config`
- `mise exec -- flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets`
- `mise exec -- flate diff images -p ./kubernetes/flux/cluster -o json`
- live read-only check: `vmcp-home-ops-workbench` service is present on port 4483 with a ready endpoint and Ready vMCP

## Follow-up

This route still relies on the trusted internal network. Before using ToolHive outside LAN/WireGuard or with broader clients, add an explicit auth boundary; ToolHive-native OIDC is the preferred direction.
