### PR TITLE
fix(ci): narrow image pull tool setup

### DIFF
--- a/.github/workflows/image-pull.yaml
+++ b/.github/workflows/image-pull.yaml
@@ -81,12 +81,19 @@ jobs:
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
           cache: false
-          install_args: talosctl
+          install: false
 
       - name: Pull image
         env:
           IMAGE: ${{ matrix.image }}
-        run: mise exec -- talosctl --nodes "${NODE}" image pull "${IMAGE}"
+        run: |
+          TALOSCTL_VERSION="$(awk -F'"' '$1 == "talosctl = " { print $2 }' .mise/config.toml)"
+          if [ -z "${TALOSCTL_VERSION}" ]; then
+            echo "::error::Could not read talosctl version from .mise/config.toml"
+            exit 1
+          fi
+
+          mise exec -C /tmp "talosctl@${TALOSCTL_VERSION}" -- talosctl --nodes "${NODE}" image pull "${IMAGE}"
 
   success:
     if: ${{ !cancelled() }}


### PR DESCRIPTION
## Summary

- avoid installing the full repo mise toolchain in the self-hosted Image Pull worker
- read the pinned talosctl version from .mise/config.toml
- run talosctl through an explicit mise tool spec from /tmp so repo hooks and unrelated npm-backed tools are not activated

## Validation

- mise exec -- oxfmt --check .github/workflows/image-pull.yaml
- mise exec -- actionlint .github/workflows/image-pull.yaml
- mise exec -- zizmor --offline .github/workflows/image-pull.yaml
- mise exec -C /tmp talosctl@1.13.4 -- talosctl version --client --short

## Notes

This targets the current Image Pull failures on open Renovate PRs where the runner failed while trying to install npm:oxfmt before reaching talosctl image pull.