### PR TITLE
feat(ci): enforce lint in CI and define mise update policy

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -23,6 +23,8 @@
   color: "027fa0"
 - name: renovate/helm
   color: "027fa0"
+- name: renovate/mise
+  color: "027fa0"
 - name: renovate/talos
   color: "027fa0"
 # Semantic Types

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
           cache: false
-          install: false
+          install_args: actionlint oxfmt zizmor
 
       - name: Lint workflows
         run: mise exec -- actionlint

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Lint
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          cache: false
+          install: false
+
+      - name: Lint workflows
+        run: mise exec -- actionlint
+
+      - name: Audit workflows
+        run: mise exec -- zizmor --offline .github/workflows
+
+      - name: Check formatting
+        run: mise exec -- oxfmt --check . '!**/*.sops.yaml' '!**/*.sops.yml'

--- a/.lefthook.toml
+++ b/.lefthook.toml
@@ -8,3 +8,7 @@ skip = true
 
 [pre-commit.commands.format-yaml]
 exclude = ["?*.sops.yaml", "?*.sops.yml"]
+
+[pre-commit.commands.actionlint]
+glob = [".github/workflows/*.yaml"]
+run = "actionlint {staged_files}"

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -57,6 +57,30 @@
       automergeType: "branch",
       ignoreTests: true,
     },
+    // Auto-merge mise hygiene tools once Lint passes
+    {
+      description: "Auto-merge mise hygiene tools",
+      matchManagers: ["mise"],
+      matchDepNames: ["actionlint", "oxfmt", "zizmor", "lefthook"],
+      matchUpdateTypes: ["minor", "patch"],
+      automerge: true,
+      automergeType: "pr",
+      ignoreTests: false,
+    },
+    // mise cluster-coupled CLIs must track talos/machineconfig.yaml.j2 — manual
+    {
+      description: "Manual mise cluster-coupled tools",
+      matchManagers: ["mise"],
+      matchDepNames: ["kubectl", "talosctl"],
+      automerge: false,
+    },
+    // mise flate must stay in lockstep with CI render — manual
+    {
+      description: "Manual mise flate",
+      matchManagers: ["mise"],
+      matchDepNames: ["github:home-operations/flate"],
+      automerge: false,
+    },
     // Grouping rules
     {
       description: "Actions Runner Controller Group",
@@ -114,6 +138,28 @@
       },
       minimumGroupSize: 2,
     },
+    {
+      description: "Align kubectl CLI with the Kubernetes version",
+      groupName: "kubernetes",
+      matchManagers: ["mise"],
+      matchDepNames: ["kubectl"],
+    },
+    {
+      description: "Talos node image and CLI",
+      groupName: "talos",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["siderolabs/talos"],
+      minimumGroupSize: 2,
+      group: {
+        commitMessageTopic: "{{{groupName}}} group",
+      },
+    },
+    {
+      description: "Align talosctl CLI with the Talos version",
+      groupName: "talos",
+      matchManagers: ["mise"],
+      matchDepNames: ["talosctl"],
+    },
     // Labeling rules
     {
       matchUpdateTypes: ["major"],
@@ -146,6 +192,10 @@
     {
       matchDatasources: ["github-releases"],
       addLabels: ["renovate/github-release"],
+    },
+    {
+      matchManagers: ["mise"],
+      addLabels: ["renovate/mise"],
     },
   ],
 }


### PR DESCRIPTION
Adds the CI-enforcement layer the repo was missing and defines a mise update policy for Renovate. Split out from the renovate-review workflow audit.

## What

**`lint.yaml`** — new workflow running `actionlint`, `zizmor --offline`, and `oxfmt --check` on PRs to `main`. Uses `install: false` + `mise exec` so it pulls only the lint tools, not the whole toolchain. All three are green on the current tree.

**`.lefthook.toml`** — adds a local `actionlint` pre-commit hook. The shared `home-operations/.github` config already runs zizmor/oxfmt/shellcheck on commit, but not actionlint.

**`.renovaterc.json5`** — mise update policy:
- Automerge hygiene tools (actionlint, oxfmt, zizmor, lefthook) on minor/patch, gated on Lint.
- Keep `kubectl`/`talosctl`/`flate` manual — they must track `talos/machineconfig.yaml.j2` and CI render parity.
- Group `kubectl`↔`kubernetes` and `talosctl`↔`talos` so an aligned CLI+image bump co-locates in one PR.

**`.github/labels.yaml`** — registers `renovate/mise` (label-sync runs with `delete-other-labels: true`, so an unregistered label would be deleted daily).

## Why now

Local lefthook hygiene never runs for Renovate commits, GitHub web edits, or contributors without the hook installed. This adds server-side enforcement and fills the one check (actionlint) the shared lefthook config doesn't cover.

## Follow-ups before this fully bites
- [ ] Add **Lint** to branch-protection required checks on `main`, or the `ignoreTests: false` automerge gate is cosmetic.
- [ ] Grouping is best-effort co-location (fires only when both update in the same Renovate run); the `automerge: false` rules are the real alignment guarantee.
- [ ] Confirm the mise `matchDepNames` + grouping against the next real mise PR and the Renovate dependency dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)