### PR TITLE
ci: add downflate pilot

### DIFF
--- a/kubernetes/apps/flux-system/downflate/app/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/downflate/app/externalsecret.yaml
@@ -12,11 +12,11 @@ spec:
     name: downflate-secret
     template:
       data:
-        DOWNFLATE_GITHUB_APP_CLIENT_ID: "{{ .GITHUB_APP_CLIENT_ID }}"
-        DOWNFLATE_GITHUB_APP_PRIVATE_KEY: "{{ .GITHUB_APP_PRIVATE_KEY }}"
+        DOWNFLATE_GITHUB_APP_CLIENT_ID: "{{ .BOT_APP_CLIENT_ID }}"
+        DOWNFLATE_GITHUB_APP_PRIVATE_KEY: "{{ .BOT_APP_PRIVATE_KEY }}"
         DOWNFLATE_WEBHOOK_SECRET: "{{ .DOWNFLATE_WEBHOOK_SECRET }}"
   dataFrom:
     - extract:
         key: downflate
     - extract:
-        key: github
+        key: bot-ler

--- a/kubernetes/apps/flux-system/downflate/app/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/downflate/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: downflate
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: downflate-secret
+    template:
+      data:
+        DOWNFLATE_GITHUB_APP_CLIENT_ID: "{{ .GITHUB_APP_CLIENT_ID }}"
+        DOWNFLATE_GITHUB_APP_PRIVATE_KEY: "{{ .GITHUB_APP_PRIVATE_KEY }}"
+        DOWNFLATE_WEBHOOK_SECRET: "{{ .DOWNFLATE_WEBHOOK_SECRET }}"
+  dataFrom:
+    - extract:
+        key: downflate
+    - extract:
+        key: github

--- a/kubernetes/apps/flux-system/downflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/downflate/app/helmrelease.yaml
@@ -1,0 +1,94 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: downflate
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: downflate
+  interval: 1h
+  values:
+    controllers:
+      downflate:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/home-operations/downflate
+              tag: main@sha256:82b1993bf5e3ad1d54bf1db6b53f4230e0cd52f29976176eba41f76bb0a7b4e1
+            env:
+              DOWNFLATE_ADDR: :80
+              DOWNFLATE_CLUSTER_PATH: ./kubernetes/flux/cluster
+              DOWNFLATE_NODES:
+                valueFrom:
+                  fieldRef:
+                    fieldPath: spec.nodeName
+              DOWNFLATE_REPO: github://alex-matthews/home-ops
+              DOWNFLATE_RESTRICT_EGRESS: "true"
+              DOWNFLATE_STATUS_CONTEXT: Downflate
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: &port 80
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 1Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        annotations:
+          gatus.home-operations.com/endpoint: |-
+            conditions: ["[STATUS] == 404"]
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-external
+            namespace: network
+    persistence:
+      talos:
+        type: secret
+        name: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /var/run/secrets/talos.dev
+            readOnly: true
+      tmpfs:
+        type: emptyDir
+        advancedMounts:
+          downflate:
+            app:
+              - path: /.cache
+                subPath: cache
+              - path: /tmp
+                subPath: tmp

--- a/kubernetes/apps/flux-system/downflate/app/kustomization.yaml
+++ b/kubernetes/apps/flux-system/downflate/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./rbac.yaml

--- a/kubernetes/apps/flux-system/downflate/app/ocirepository.yaml
+++ b/kubernetes/apps/flux-system/downflate/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: downflate
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/flux-system/downflate/app/rbac.yaml
+++ b/kubernetes/apps/flux-system/downflate/app/rbac.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: talos.dev/v1alpha1
+kind: ServiceAccount
+metadata:
+  name: downflate
+spec:
+  roles:
+    - os:operator

--- a/kubernetes/apps/flux-system/downflate/ks.yaml
+++ b/kubernetes/apps/flux-system/downflate/ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: downflate
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/flux-system/downflate/app
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: flux-system
+  wait: false

--- a/kubernetes/apps/flux-system/kustomization.yaml
+++ b/kubernetes/apps/flux-system/kustomization.yaml
@@ -8,6 +8,7 @@ components:
   - ../../components/sops
 resources:
   - ./namespace.yaml
+  - ./downflate/ks.yaml
   - ./flux-instance/ks.yaml
   - ./flux-operator/ks.yaml
   - ./konflate/ks.yaml


### PR DESCRIPTION
## Summary

- Add a non-required downflate deployment under `flux-system` as the pilot replacement path for Image Pull.
- Expose `downflate.${SECRET_DOMAIN}` for pull-request webhooks.
- Wire downflate's webhook secret and shared GitHub App credentials through External Secrets.
- Add a Talos `os:operator` service account and mount its talosconfig.
- Target the downflate pod's node with `DOWNFLATE_NODES=spec.nodeName`, matching buroa's current in-cluster pattern; Spegel remains the cluster-local fan-out/cache layer.

This does not change branch rulesets, Image Pull, or ARC. PR #1424 should stay draft until this pilot has reconciled and produced reliable non-required `Downflate` statuses.

## Prerequisites before merge

- The downflate webhook secret exists in 1Password.
- The shared GitHub App credential item exists in 1Password using the current bot credential shape.
- GitHub App has Contents read and Commit statuses write permissions.
- GitHub pull request webhook points at `https://downflate.${SECRET_DOMAIN}/hooks` with the matching secret.

## Validation

- `mise exec -- kubectl kustomize kubernetes/apps/flux-system/downflate/app`
- `mise exec -- kubectl kustomize kubernetes/apps/flux-system`
- `mise exec --no-deps -- oxfmt --check kubernetes/apps/flux-system/downflate/app/helmrelease.yaml kubernetes/apps/flux-system/downflate/app/externalsecret.yaml kubernetes/apps/flux-system/downflate/app/kustomization.yaml kubernetes/apps/flux-system/downflate/app/ocirepository.yaml kubernetes/apps/flux-system/downflate/app/rbac.yaml kubernetes/apps/flux-system/downflate/ks.yaml kubernetes/apps/flux-system/kustomization.yaml`
- `mise exec -- flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets` - 203 passed with the known offline `cloudflare-tunnel-id-secret` warning
- `mise exec -- flate diff images -p ./kubernetes/flux/cluster --base origin/main -o json` - only `ghcr.io/home-operations/downflate:main@sha256:82b1993bf5e3ad1d54bf1db6b53f4230e0cd52f29976176eba41f76bb0a7b4e1`
- `git diff --check`

## Acceptance

- downflate reconciles Ready in `flux-system`.
- A test Renovate PR gets a non-required `Downflate` commit status.
- Required checks remain `Image Pull - Success`, `Lint`, and `Konflate`.
- Image Pull and ARC remain in place until downflate has proven reliable and the ruleset cutover is explicitly approved.

