### PR TITLE
feat: deploy drm-exporter

### DIFF
--- a/kubernetes/apps/kube-system/drm-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/drm-exporter/app/helmrelease.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: drm-exporter
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: drm-exporter
+  interval: 1h
+  values:
+    dra:
+      enabled: true
+      deviceClassName: gpu.intel.com
+    securityContext:
+      capabilities:
+        add:
+          - PERFMON
+    monitoring:
+      serviceMonitor:
+        enabled: true
+      dashboards:
+        enabled: true
+        grafanaOperator:
+          enabled: true
+          matchLabels:
+            dashboards: grafana
+    resources:
+      requests:
+        cpu: 10m
+      limits:
+        memory: 128Mi
+    nodeSelector:
+      node.kubernetes.io/gpu: "true"

--- a/kubernetes/apps/kube-system/drm-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/drm-exporter/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/kube-system/drm-exporter/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/drm-exporter/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: drm-exporter
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.2.4
+  url: oci://ghcr.io/home-operations/charts/drm-exporter

--- a/kubernetes/apps/kube-system/drm-exporter/ks.yaml
+++ b/kubernetes/apps/kube-system/drm-exporter/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: drm-exporter
+spec:
+  dependsOn:
+    - name: intel-gpu-resource-driver
+  interval: 1h
+  path: ./kubernetes/apps/kube-system/drm-exporter/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: kube-system
+  wait: false

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./cilium/ks.yaml
   - ./coredns/ks.yaml
   - ./descheduler/ks.yaml
+  - ./drm-exporter/ks.yaml
   - ./intel-gpu-resource-driver/ks.yaml
   - ./metrics-server/ks.yaml
   - ./reloader/ks.yaml

--- a/kubernetes/apps/kube-system/namespace.yaml
+++ b/kubernetes/apps/kube-system/namespace.yaml
@@ -5,3 +5,5 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    resource.kubernetes.io/admin-access: "true"


### PR DESCRIPTION
## Summary

- Deploy `home-operations/drm-exporter` chart `0.2.4` in `kube-system`.
- Use Intel DRA with `gpu.intel.com`, upstream monitor defaults, and `PERFMON` only.
- Enable the chart ServiceMonitor and GrafanaDashboard for Prometheus/Grafana discovery.
- Label `kube-system` with `resource.kubernetes.io/admin-access: "true"` so the DRA admin-access monitor claim can be created.
- Scope the DaemonSet to nodes labeled `node.kubernetes.io/gpu=true`.

## Rationale

This is observability only. The existing Intel GPU resource driver remains the scheduling path, and Plex continues to use its existing `gpu.intel.com` ResourceClaimTemplate.

The deployment shape is based on onedr0p's current Intel DRA implementation: run the exporter next to the Intel GPU resource driver in `kube-system`, depend on `intel-gpu-resource-driver`, use DRA instead of raw `/dev/dri` hostPath access, and grant only `PERFMON` on Talos.

## Validation

- `mise exec -- kubectl kustomize kubernetes/apps/kube-system/drm-exporter/app`
- `mise exec -- kubectl kustomize kubernetes/apps/kube-system`
- `mise exec -- flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets`
  - Passed: `194 passed`
  - Existing offline warning: `cloudflare-tunnel-id-secret` substituteFrom cannot be read offline
- `mise exec -- flate diff images -p ./kubernetes/flux/cluster -o json`
  - New image: `ghcr.io/home-operations/drm-exporter@sha256:1ccf3c6db20bcd95bc4d69eac7a5288c92543b34adbe053004c1b739fd0208ef`

## Rollback

Remove `./drm-exporter/ks.yaml` from `kubernetes/apps/kube-system/kustomization.yaml`, delete `kubernetes/apps/kube-system/drm-exporter/`, and remove the `resource.kubernetes.io/admin-access` label from `kube-system` if no other kube-system DRA monitor claims need it.
