### PR TITLE
fix: allow maintainerr ui bootstrap writes

### DIFF
--- a/kubernetes/apps/default/maintainerr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/maintainerr/app/helmrelease.yaml
@@ -51,7 +51,7 @@ spec:
                   periodSeconds: 10
             securityContext:
               allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
+              readOnlyRootFilesystem: false
               capabilities: { drop: ["ALL"] }
             resources:
               requests:


### PR DESCRIPTION
## Summary
- set Maintainerr `readOnlyRootFilesystem` to `false`
- keep the rest of the deployment shape unchanged

## Why
The merged deployment crashes immediately because Maintainerr rewrites static UI files at startup:

```text
sed: can't create temp file '/opt/app/apps/server/dist/ui/apple-touch-icon.pngXXXXXX': Read-only file system
Failed to rewrite UI base paths under /opt/app/apps/server/dist/ui.
Please run the container with a writable filesystem and try again.
```

This is a container startup contract issue, not a render or Flux issue. The pod is in `CrashLoopBackOff` with that exact log line.

## Peer Check
- `bjw-s-labs/home-ops` has the Maintainerr `readOnlyRootFilesystem` line commented out.
- Several current Maintainerr deployments using `3.15.x` explicitly set `readOnlyRootFilesystem: false`.
- One peer keeps read-only root with an init-container plus `/opt/app/apps/server/dist/ui` emptyDir overlay, but that is more bespoke than this repo needs for a first deploy.

## Validation
- `mise exec -- kubectl kustomize /Users/alex/home-ops-pr1220/kubernetes/apps/default/maintainerr/app`
- `mise exec --no-deps -- oxfmt --check /Users/alex/home-ops-pr1220/kubernetes/apps/default/maintainerr/app/helmrelease.yaml`
- `git diff --check`
- `MINIJINJA_CONFIG_FILE=/Users/alex/home-ops-pr1220/.minijinja.toml flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets`

## Validation Notes
- Offline flate render still warns about missing `cloudflare-tunnel-id-secret`, unrelated to Maintainerr.
- Local `flate diff images` failed only from the linked Git worktree with `resolve HEAD: reference not found`; the same command succeeds from the primary checkout, so this appears to be a flate/git-worktree resolver issue rather than a manifest issue.
