### PR TITLE
fix: bootstrap maintainerr with fresh pvc

### DIFF
--- a/kubernetes/apps/default/maintainerr/app/kustomization.yaml
+++ b/kubernetes/apps/default/maintainerr/app/kustomization.yaml
@@ -2,6 +2,16 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+components:
+  - ../../../../components/volsync
+patches:
+  # Fresh install: there are no restic snapshots yet, so avoid bootstrapping
+  # the first PVC from an empty VolSync restore image.
+  - patch: |-
+      - op: remove
+        path: /spec/dataSourceRef
+    target:
+      kind: PersistentVolumeClaim
 resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/default/maintainerr/ks.yaml
+++ b/kubernetes/apps/default/maintainerr/ks.yaml
@@ -5,8 +5,6 @@ kind: Kustomization
 metadata:
   name: maintainerr
 spec:
-  components:
-    - ../../../../components/volsync
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph


### PR DESCRIPTION
## Summary

- move Maintainerr's shared VolSync component into the app-level kustomization
- patch the generated PVC to remove `dataSourceRef` for the first fresh install
- keep the VolSync backup resources in place so future scheduled backups still run

## Why

After #1220 and #1376 merged, Maintainerr still crashed during data-dir bootstrap. Live checks showed:

- the app pod had `readOnlyRootFilesystem: false`
- `/opt/data` was mounted from the `maintainerr` PVC as rw
- the PVC root was `0:100` with mode `2775`
- the same image and UID/GID could pass `fs.accessSync('/opt/data', R_OK | W_OK)`
- actual file creation on the VolSync-populated PVC failed as both UID `1032:100` and root with `Bad message` / errno `-74`
- a throwaway plain `ceph-block` PVC without `dataSourceRef` wrote normally as `1032:100`

The VolSync restore status for this brand-new app created a restic repository, found no snapshots, and still produced the snapshot backing the claim. There is no Maintainerr data to preserve yet, so the safer bootstrap path is a normal fresh PVC, then scheduled VolSync backups once the app has initialized data.

## Validation

- `kubectl kustomize /Users/alex/home-ops-pr1220/kubernetes/apps/default/maintainerr/app` shows the generated PVC without `dataSourceRef`
- `flate build ks maintainerr -n default -p /Users/alex/home-ops-pr1220/kubernetes/flux/cluster --allow-missing-secrets --no-progress` shows the Maintainerr PVC without `dataSourceRef`
- `flate test all -p /Users/alex/home-ops-pr1220/kubernetes/flux/cluster --allow-missing-secrets`
- `oxfmt --check` on the changed YAML files
