### PR TITLE
fix: restore maintainerr volsync bootstrap

### DIFF
--- a/kubernetes/apps/default/maintainerr/app/kustomization.yaml
+++ b/kubernetes/apps/default/maintainerr/app/kustomization.yaml
@@ -2,16 +2,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-components:
-  - ../../../../components/volsync
-patches:
-  # Fresh install: there are no restic snapshots yet, so avoid bootstrapping
-  # the first PVC from an empty VolSync restore image.
-  - patch: |-
-      - op: remove
-        path: /spec/dataSourceRef
-    target:
-      kind: PersistentVolumeClaim
 resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/default/maintainerr/ks.yaml
+++ b/kubernetes/apps/default/maintainerr/ks.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 metadata:
   name: maintainerr
 spec:
+  components:
+    - ../../../../components/volsync
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph


### PR DESCRIPTION
## Summary

- return Maintainerr to the shared VolSync component in `ks.yaml`
- remove the temporary app-level PVC patch that stripped `dataSourceRef`
- restore normal hands-free PVC population behavior for future cluster bootstrap

## Live Recovery State

Before this PR, the temporary patch let Maintainerr boot from a plain fresh PVC. To normalize safely, I first refreshed the VolSync restore side:

- took a fresh local VolSync snapshot from the healthy Maintainerr PVC
- re-triggered `ReplicationDestination/default/maintainerr-dst`
- `maintainerr-dst` now has `latestImage: volsync-maintainerr-dst-dest-20260625051959`
- that destination image restored restic snapshot `6d74202c`
- cloned `volsync-maintainerr-dst-dest-20260625051959` into a disposable PVC and verified it contains `maintainerr.sqlite`, logs, overlays, and is writable as `1032:100`

After this merges, the live PVC must be recreated once so Kubernetes can bind it with the restored `dataSourceRef`. That is the normal VolSync shape and preserves future clean-cluster auto-population.

## Validation

- `flate build ks maintainerr -n default -p /Users/alex/home-ops-pr1220/kubernetes/flux/cluster --allow-missing-secrets --no-progress` shows the Maintainerr PVC with `dataSourceRef: ReplicationDestination/maintainerr-dst`
- `flate test all -p /Users/alex/home-ops-pr1220/kubernetes/flux/cluster --allow-missing-secrets`
- `oxfmt --check` on the changed YAML files
