### PR TITLE
test: deploy volsync smoke app

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -25,3 +25,4 @@ resources:
   - ./sonarr/ks.yaml
   - ./tautulli/ks.yaml
   - ./thelounge/ks.yaml
+  - ./volsync-smoke/ks.yaml

--- a/kubernetes/apps/default/volsync-smoke/app/helmrelease.yaml
+++ b/kubernetes/apps/default/volsync-smoke/app/helmrelease.yaml
@@ -1,0 +1,55 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: volsync-smoke
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: volsync-smoke
+  interval: 1h
+  values:
+    controllers:
+      volsync-smoke:
+        containers:
+          app:
+            image:
+              repository: docker.io/library/busybox
+              tag: 1.37@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028
+            command:
+              - /bin/sh
+              - -c
+            args:
+              - |
+                set -eu
+                mkdir -p /data
+                printf 'boot=%s uid=%s gid=%s\n' "$(date -u +%FT%TZ)" "$(id -u)" "$(id -g)" >> /data/boots.log
+                echo ready > /data/ready
+                trap 'exit 0' TERM INT
+                while true; do
+                  date -u +%FT%TZ > /data/heartbeat
+                  sleep 300 &
+                  wait "$!"
+                done
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 5m
+              limits:
+                memory: 64Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1032
+        runAsGroup: 100
+        fsGroup: 100
+        fsGroupChangePolicy: OnRootMismatch
+    persistence:
+      data:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /data

--- a/kubernetes/apps/default/volsync-smoke/app/kustomization.yaml
+++ b/kubernetes/apps/default/volsync-smoke/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/default/volsync-smoke/app/ocirepository.yaml
+++ b/kubernetes/apps/default/volsync-smoke/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: volsync-smoke
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/volsync-smoke/ks.yaml
+++ b/kubernetes/apps/default/volsync-smoke/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: volsync-smoke
+spec:
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/default/volsync-smoke/app
+  postBuild:
+    substitute:
+      APP: volsync-smoke
+      VOLSYNC_CAPACITY: 1Gi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: default
+  wait: false


### PR DESCRIPTION
## Summary
- add a disposable `volsync-smoke` app in `default` using the standard VolSync component
- mount the generated PVC at `/data` and write boot/heartbeat markers as UID 1032/GID 100
- keep the app private: no service, route, external secret, or public surface

## Validation
- `kubectl kustomize kubernetes/apps/default/volsync-smoke/app`
- `kubectl kustomize kubernetes/apps/default`
- `flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets`
- `oxfmt --check kubernetes/apps/default/kustomization.yaml kubernetes/apps/default/volsync-smoke/ks.yaml kubernetes/apps/default/volsync-smoke/app/kustomization.yaml kubernetes/apps/default/volsync-smoke/app/helmrelease.yaml kubernetes/apps/default/volsync-smoke/app/ocirepository.yaml`
- `git diff --check`

## Live test plan
After merge, verify that Flux creates the PVC from `ReplicationDestination/volsync-smoke-dst`, the BusyBox pod can write to `/data`, and local/R2 VolSync snapshots complete. This app is disposable and can be removed after the smoke test.