### PR TITLE
ci: tighten automation review posture

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,6 +4,15 @@ name: Lint
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/actionlint.yaml
+      - .github/workflows/**/*.yaml
+      - .github/workflows/**/*.yml
+      - .renovate/**.json5
+      - .renovaterc.json5
   pull_request:
     branches:
       - main

--- a/.github/workflows/render.yaml
+++ b/.github/workflows/render.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Render
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - kubernetes/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  render:
+    name: Render
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          cache: false
+          install_args: github:home-operations/flate
+
+      - name: Render cluster
+        run: mise exec -- flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets

--- a/.github/workflows/renovate-review.yaml
+++ b/.github/workflows/renovate-review.yaml
@@ -9,6 +9,16 @@ on:
         description: Renovate PR number to review
         required: true
         type: number
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+    paths:
+      - kubernetes/**
 
 env:
   FORCE_REVIEW: ${{ github.event_name == 'workflow_dispatch' }}
@@ -88,7 +98,7 @@ jobs:
 
           jq -R . < "${pr_file_paths}" | jq -s . > "${pr_file_paths_json}"
 
-          if ! grep -Eq '^(kubernetes|bootstrap|talos)/' "${pr_file_paths}"; then
+          if ! grep -Eq '^kubernetes/' "${pr_file_paths}"; then
             skip "Skipping; PR #${PR} does not touch reviewed paths."
           fi
 

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -32,16 +32,6 @@
       ignoreTests: true,
     },
     {
-      description: "Auto-merge trusted GitHub Actions",
-      matchManagers: ["github-actions"],
-      matchPackageNames: ["/^actions\\//", "/^renovatebot\\//"],
-      matchUpdateTypes: ["minor", "patch", "digest"],
-      automerge: true,
-      automergeType: "branch",
-      minimumReleaseAge: "1 minute",
-      ignoreTests: true,
-    },
-    {
       description: "Auto-merge Grafana dashboards",
       matchDatasources: ["custom.grafana-dashboards"],
       matchUpdateTypes: ["major"],
@@ -50,12 +40,10 @@
       ignoreTests: true,
     },
     {
-      description: "Auto-merge Renovate presets",
+      description: "Require review for Renovate presets",
       matchManagers: ["renovate-config"],
       matchUpdateTypes: ["minor", "patch"],
-      automerge: true,
-      automergeType: "branch",
-      ignoreTests: true,
+      automerge: false,
     },
     // Grouping rules
     {

--- a/README.md
+++ b/README.md
@@ -91,17 +91,22 @@ Common additions include `externalsecret.yaml`, `pvc.yaml`, `httproute.yaml`,
 
 ## Automation / CI
 
-Renovate opens dependency update pull requests for charts, containers, GitHub
-Actions, and other versioned references.
+Renovate manages dependency updates for charts, containers, GitHub Actions, and
+other versioned references. Most updates use pull requests; selected low-risk
+classes may branch-automerge.
 
 Pull request checks and reviewers are:
 
-| Check                | Status   | Purpose                                                |
-| -------------------- | -------- | ------------------------------------------------------ |
-| `Lint`               | Required | Lints workflows and structured files.                  |
-| `Image Pull`         | Required | Calculates changed images and pre-pulls them.          |
-| `Konflate`           | Required | Posts rendered Flate diffs and checks.                 |
-| `Renovate PR Review` | Advisory | Posts Claude-backed reviews for eligible Renovate PRs. |
+| Check                | Status   | Purpose                                              |
+| -------------------- | -------- | ---------------------------------------------------- |
+| `Lint`               | Required | Checks workflow syntax, security, and file format.   |
+| `Image Pull`         | Required | Finds image changes and pre-pulls them on the nodes. |
+| `Konflate`           | Required | Renders manifests, posts diffs, and verifies images. |
+| `Renovate PR Review` | Advisory | Reviews eligible Renovate PRs with Claude.           |
+
+`Render` is a GitHub-hosted post-merge alarm that runs Flate against `main`
+after changes under `kubernetes/`. It does not replace Konflate as the pull
+request render and diff gate.
 
 `Label Sync` keeps repository labels consistent.
 

--- a/docs/guides/repo-guide.md
+++ b/docs/guides/repo-guide.md
@@ -10,7 +10,8 @@ commands. Agent behavior and change-control rules live in
   ordering.
 - `.github/actionlint.yaml`: actionlint configuration.
 - `.github/labels.yaml`: label definitions synced by CI.
-- `.github/workflows/`: CI, Renovate, Renovate PR Review, and label sync.
+- `.github/workflows/`: CI, post-merge render alarm, Renovate, Renovate PR
+  Review, and label sync.
 - `.mise/config.toml`: repo-pinned tool versions and local environment.
 - `.renovaterc.json5`: Renovate configuration.
 - `bootstrap/`: one-time cluster bootstrap helpers.
@@ -134,6 +135,30 @@ cluster actions, bootstrap, Talos, and restore operations. Changes to Justfiles
 are formatted by Lefthook. Image Pull currently filters on `kubernetes/**/*`, so
 changes under `kubernetes/` can trigger it even when the touched file is
 local/operator tooling rather than rendered cluster state.
+
+The `Render` workflow is a GitHub-hosted post-merge alarm, not a required pull
+request check. It runs Flate on `main` after changes under `kubernetes/` so
+merge trains can stay lightweight while the applied branch still gets rendered.
+Konflate remains the pull request render and diff gate.
+
+### Bypass Merges
+
+Use a bypass merge only when a cluster outage or cluster-hosted automation
+failure prevents `Konflate` or `Image Pull` from reporting. Do not use it to
+skip a check that reported a real repository, render, image, or workflow
+failure.
+
+Before bypassing, validate the smallest relevant set locally:
+
+```sh
+mise exec -- flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets
+mise exec -- flate diff images -p ./kubernetes/flux/cluster -o json
+```
+
+For workflow or Renovate configuration changes, also run the formatting and
+workflow checks from the validation section. In the PR or merge note, record why
+the bypass was needed and which local commands passed. After merging, watch the
+GitHub-hosted `Render` alarm and Flux reconciliation for the merged revision.
 
 `mise` owns the repo-local environment and toolchain contract. Use it for
 environment variables, project-specific tool installation, and reproducible


### PR DESCRIPTION
## Summary
- keep GitHub Actions updates on branch automerge, but remove the 1-minute trusted-org fast lane
- disable automerge for Renovate preset updates
- restore automatic Claude review for eligible Kubernetes Renovate PRs
- add a GitHub-hosted post-merge Render alarm for changes under kubernetes/
- refresh README/repo-guide CI and bypass guidance

## Validation
- mise exec --no-deps -- actionlint
- mise exec --no-deps -- zizmor --offline .github/workflows
- mise exec --no-deps -- oxfmt --check . '!**/*.sops.yaml' '!**/*.sops.yml'
- mise exec -- flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets