### PR TITLE
ci: keep lint pull request scoped

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,15 +4,6 @@ name: Lint
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - .github/actionlint.yaml
-      - .github/workflows/**/*.yaml
-      - .github/workflows/**/*.yml
-      - .renovate/**.json5
-      - .renovaterc.json5
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Summary
- remove the post-merge push trigger from Lint
- keep Lint scoped to pull_request and workflow_dispatch
- leave Render as the only automatic post-merge alarm

## Validation
- mise exec --no-deps -- actionlint .github/workflows/lint.yaml
- mise exec --no-deps -- zizmor --offline .github/workflows/lint.yaml
- mise exec --no-deps -- oxfmt --check .github/workflows/lint.yaml