### PR TITLE
fix(hermes): restore dashboard auth

### DIFF
--- a/docs/operations/ai-workbench.md
+++ b/docs/operations/ai-workbench.md
@@ -14,6 +14,12 @@ notes should stay out of this file.
 Hermes is the interactive client. It uses the internal LiteLLM gateway by
 default and reaches tools through the ToolHive vMCP surface.
 
+The Hermes dashboard is exposed through the internal Envoy Gateway route. For
+non-loopback binds, Hermes requires a dashboard auth provider; this deployment
+uses the bundled username/password provider from `hermes-secret` through the
+existing ExternalSecret. Do not restore the obsolete `HERMES_DASHBOARD_INSECURE`
+setting for this bind mode.
+
 Current ToolHive tools:
 
 - Context7 for public documentation lookup.

--- a/kubernetes/apps/ai/hermes/app/configmap.yaml
+++ b/kubernetes/apps/ai/hermes/app/configmap.yaml
@@ -5,14 +5,16 @@ metadata:
   name: hermes-config
 data:
   config.yaml: |
-    custom_providers:
-      - name: litellm
+    _config_version: 32
+    providers:
+      litellm:
+        name: LiteLLM
         base_url: http://litellm.ai.svc.cluster.local:4000/v1
         key_env: LITELLM_MASTER_KEY
-        api_mode: chat_completions
-        model: minimax/MiniMax-M3
+        transport: chat_completions
+        default_model: minimax/MiniMax-M3
     model:
-      provider: custom:litellm
+      provider: litellm
       default: minimax/MiniMax-M3
     toolsets:
       - hermes-cli
@@ -41,6 +43,11 @@ data:
       reasoning_effort: medium
     streaming:
       enabled: false
+    skills:
+      write_approval: true
+      guard_agent_created: false
+    curator:
+      consolidate: false
     security:
       redact_secrets: true
     privacy:

--- a/kubernetes/apps/ai/hermes/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hermes/app/externalsecret.yaml
@@ -12,6 +12,9 @@ spec:
     name: hermes-secret
     template:
       data:
+        HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: "{{ .HERMES_DASHBOARD_BASIC_AUTH_PASSWORD }}"
+        HERMES_DASHBOARD_BASIC_AUTH_SECRET: "{{ .HERMES_DASHBOARD_BASIC_AUTH_SECRET }}"
+        HERMES_DASHBOARD_BASIC_AUTH_USERNAME: "{{ .HERMES_DASHBOARD_BASIC_AUTH_USERNAME }}"
         LITELLM_MASTER_KEY: "{{ .LITELLM_MASTER_KEY }}"
         MINIMAX_API_KEY: "{{ .MINIMAX_API_KEY }}"
   data:
@@ -19,6 +22,10 @@ spec:
       remoteRef:
         key: litellm
         property: LITELLM_MASTER_KEY
+    - secretKey: MINIMAX_API_KEY
+      remoteRef:
+        key: litellm
+        property: MINIMAX_API_KEY
   dataFrom:
     - extract:
         key: hermes

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -23,7 +23,6 @@ spec:
               HERMES_HOME: /opt/data
               HERMES_DASHBOARD: "1"
               HERMES_DASHBOARD_HOST: 0.0.0.0
-              HERMES_DASHBOARD_INSECURE: "1"
               HERMES_DASHBOARD_PORT: "9119"
               HOME: /opt/data
               NO_COLOR: "1"
@@ -34,6 +33,16 @@ spec:
               - gateway
               - run
               - --no-supervise
+            probes:
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &dashboardPort 9119
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
             resources:
               requests:
                 cpu: 100m
@@ -55,7 +64,7 @@ spec:
         controller: hermes
         ports:
           http:
-            port: 9119
+            port: *dashboardPort
     route:
       app:
         hostnames:


### PR DESCRIPTION
## Summary

- Migrate Hermes from legacy `custom_providers` config to the current `providers` schema and declare the current config version.
- Set the AI workbench Hermes controls for write approval, agent-created guard behavior, and curator consolidation.
- Replace obsolete `HERMES_DASHBOARD_INSECURE` usage with the bundled username/password dashboard auth provider.
- Keep ExternalSecret ownership aligned with repo convention: bulk-extract the `hermes` item for Hermes-owned dashboard auth fields, and explicitly source LiteLLM-owned keys from the `litellm` item.
- Add a TCP readiness probe on the dashboard port and document the dashboard auth contract.

## Rollout note

Keep this PR draft until the `hermes` 1Password item has these fields:

- `HERMES_DASHBOARD_BASIC_AUTH_USERNAME`
- `HERMES_DASHBOARD_BASIC_AUTH_PASSWORD`
- `HERMES_DASHBOARD_BASIC_AUTH_SECRET`

The `litellm` 1Password item provides `LITELLM_MASTER_KEY` and `MINIMAX_API_KEY`. After this reconciles, the duplicate `MINIMAX_API_KEY` field can be removed from the `hermes` item.

Live check: `ai/hermes-secret` currently exposes only `LITELLM_MASTER_KEY` and `MINIMAX_API_KEY`, so the dashboard auth fields must be present in 1Password before reconciliation.

## Validation

- `git diff --check`
- `mise exec --no-deps -- oxfmt --check kubernetes/apps/ai/hermes/app/externalsecret.yaml`
- `mise exec -- kubectl kustomize kubernetes/apps/ai/hermes/app`
- `mise exec -- flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets` - passes with the known offline `cloudflare-tunnel-id-secret` warning
- `mise exec -- flate diff images -p ./kubernetes/flux/cluster -o json` - `[]`
