### PR TITLE
feat: deploy resolute (shadow mode) plus chaski

### DIFF
--- a/kubernetes/apps/default/chaski/app/externalsecret.yaml
+++ b/kubernetes/apps/default/chaski/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: chaski
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: chaski-secret
+    template:
+      data:
+        RESOLUTE_WEBHOOK_SECRET: "{{ .RESOLUTE_WEBHOOK_SECRET }}"
+  dataFrom:
+    - extract:
+        key: resolute

--- a/kubernetes/apps/default/chaski/app/helmrelease.yaml
+++ b/kubernetes/apps/default/chaski/app/helmrelease.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: chaski
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: chaski
+  interval: 1h
+  values:
+    replicaCount: 2
+    deploymentAnnotations:
+      reloader.stakater.com/auto: "true"
+    env:
+      TZ: Pacific/Auckland
+    envFrom:
+      - secretRef:
+          name: "{{ .Release.Name }}-secret"
+    service:
+      port: 80
+    config:
+      targets:
+        resolute:
+          http:
+            url: http://resolute.default.svc.cluster.local/api/webhooks/seerr
+            headers:
+              X-Resolute-Token: '{{ env "RESOLUTE_WEBHOOK_SECRET" }}'
+      routes:
+        # Seerr -> chaski -> resolute. No title/message on the route, so the
+        # inbound Seerr JSON is forwarded verbatim (resolute's normalizer
+        # requires the Seerr-native payload; see its ADR-0001). Adding
+        # costanza later = add a target + list it here; zero Seerr changes.
+        seerr:
+          target: resolute
+          verify:
+            token:
+              header: Authorization
+              secret: '{{ env "RESOLUTE_WEBHOOK_SECRET" }}'
+    monitoring:
+      serviceMonitor:
+        enabled: true
+    resources:
+      requests:
+        cpu: 10m
+      limits:
+        memory: 128Mi

--- a/kubernetes/apps/default/chaski/app/kustomization.yaml
+++ b/kubernetes/apps/default/chaski/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/default/chaski/app/ocirepository.yaml
+++ b/kubernetes/apps/default/chaski/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: chaski
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.3.1
+  url: oci://ghcr.io/home-operations/charts/chaski

--- a/kubernetes/apps/default/chaski/ks.yaml
+++ b/kubernetes/apps/default/chaski/ks.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: chaski
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/default/chaski/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: default
+  wait: false

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./autobrr/ks.yaml
   - ./bazarr/ks.yaml
   - ./brrpolice/ks.yaml
+  - ./chaski/ks.yaml
   - ./maintainerr/ks.yaml
   - ./plex/ks.yaml
   - ./prowlarr/ks.yaml
@@ -20,6 +21,7 @@ resources:
   - ./radarr/ks.yaml
   - ./radarr-se/ks.yaml
   - ./recyclarr/ks.yaml
+  - ./resolute/ks.yaml
   - ./sabnzbd/ks.yaml
   - ./seerr/ks.yaml
   - ./sonarr/ks.yaml

--- a/kubernetes/apps/default/resolute/app/externalsecret.yaml
+++ b/kubernetes/apps/default/resolute/app/externalsecret.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: resolute
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: resolute-secret
+    template:
+      data:
+        RESOLUTE_SEERR__API_KEY: "{{ .SEERR_API_KEY }}"
+        RESOLUTE_SONARR__API_KEY: "{{ .SONARR_API_KEY }}"
+        RESOLUTE_JUDGE__API_KEY: "{{ .RESOLUTE_MODEL_API_KEY }}"
+        RESOLUTE_SEERR__WEBHOOK_SHARED_SECRET: "{{ .RESOLUTE_WEBHOOK_SECRET }}"
+        RESOLUTE_EXECUTE_TOKEN: "{{ .RESOLUTE_EXECUTE_TOKEN }}"
+        RESOLUTE_API_TOKEN: "{{ .RESOLUTE_API_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: seerr
+    - extract:
+        key: sonarr
+    - extract:
+        key: resolute

--- a/kubernetes/apps/default/resolute/app/helmrelease.yaml
+++ b/kubernetes/apps/default/resolute/app/helmrelease.yaml
@@ -1,0 +1,142 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: resolute
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: resolute
+  interval: 1h
+  values:
+    controllers:
+      resolute:
+        # SQLite single-writer: keep exactly 1 replica. Do not scale this.
+        replicas: 1
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image: &image
+              repository: ghcr.io/alex-matthews/resolute
+              # Digest-pinned :main until release-please cuts the first
+              # semver release; switch to the vX.Y.Z tag then (Renovate
+              # takes over from there).
+              tag: main@sha256:135effa8e3e843d48d7279f5327d60d27270564d77661b138523ac74ac0d3b0d
+            env:
+              TZ: Pacific/Auckland
+              RESOLUTE_MODE: shadow # rollout: shadow -> recommend -> approve
+              RESOLUTE_ALLOW_WRITES: "false" # master write switch; keep false until resolute docs/rollout.md phase 3
+              RESOLUTE_AUTO_APPROVE_ENABLED: "false"
+              RESOLUTE_DB_PATH: /data/resolute.db
+              RESOLUTE_POLICY_PATH: /config/policy.yaml
+              RESOLUTE_LISTEN_PORT: &port 80
+              RESOLUTE_SEERR__URL: http://seerr.default.svc.cluster.local
+              RESOLUTE_SONARR__URL: http://sonarr.default.svc.cluster.local
+              RESOLUTE_SEERR__PROFILE_NAME_1080P: WEB-1080p # must match Sonarr profile names exactly
+              RESOLUTE_SEERR__PROFILE_NAME_2160P: WEB-2160p
+              RESOLUTE_JUDGE__ENABLED: "false"
+              RESOLUTE_JUDGE__BASE_URL: http://litellm.ai.svc.cluster.local/v1
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
+            probes:
+              liveness:
+                enabled: true
+                spec:
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /readyz
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 256Mi
+      # Nightly sweep of pending Seerr TV requests, via the API so the
+      # SQLite writer and its RWO PVC stay with the API pod. The endpoint
+      # only decides and records; it never executes writes.
+      review:
+        type: cronjob
+        cronjob:
+          schedule: "0 4 * * *"
+          successfulJobsHistory: 1
+          failedJobsHistory: 1
+        containers:
+          app:
+            image: *image
+            command:
+              - resolute
+              - review-pending
+              - --remote
+              - http://resolute.default.svc.cluster.local
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1032
+        runAsGroup: 100
+        fsGroup: 100
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: resolute
+        ports:
+          http:
+            port: *port
+    # /metrics is served on the http port (unauthenticated; the bearer gate
+    # only covers /api/*), so scrape the http port with an explicit path.
+    serviceMonitor:
+      app:
+        endpoints:
+          - port: http
+            path: /metrics
+            interval: 1m
+            scrapeTimeout: 30s
+    # Internal-only: Seerr reaches resolute in-cluster; no route needed.
+    persistence:
+      data:
+        existingClaim: "{{ .Release.Name }}"
+        advancedMounts:
+          resolute:
+            app:
+              - path: /data
+      policy:
+        type: configMap
+        name: resolute-policy
+        advancedMounts:
+          resolute:
+            app:
+              - path: /config/policy.yaml
+                subPath: policy.yaml
+                readOnly: true
+      tmpfs:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/default/resolute/app/kustomization.yaml
+++ b/kubernetes/apps/default/resolute/app/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+configMapGenerator:
+  - name: resolute-policy
+    files:
+      - ./resources/policy.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/default/resolute/app/ocirepository.yaml
+++ b/kubernetes/apps/default/resolute/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: resolute
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/resolute/app/resources/policy.yaml
+++ b/kubernetes/apps/default/resolute/app/resources/policy.yaml
@@ -1,0 +1,73 @@
+# Household policy: the editable vocabulary the deterministic engine scores with.
+# Keep this file in git; it is reviewed calibration state, not runtime config.
+
+version: 1
+
+# low | medium | high — raise this when the pool fills up; high pressure blocks
+# non-pinned 2160p decisions below high confidence.
+storage_pressure: low
+
+# Above this many requested episodes, 2160p requires high confidence.
+max_episodes_2160p: 80
+
+weights:
+  visual_genre: 1.6
+  network_tier: 1.0
+  era: 0.8
+  acclaim: 1.0
+  episode_burden: 1.4
+  requester_preference: 1.0
+  franchise_priority: 3.0
+  storage_pressure: 1.2
+
+thresholds:
+  uhd_score: 2.0 # household score >= this -> 2160p
+  hd_score: -0.5 # household score <= this -> 1080p; in between -> ambiguous
+  high_confidence_margin: 1.5
+
+visual_genres:
+  - documentary
+  - sci-fi & fantasy
+  - science fiction
+  - animation
+  - action & adventure
+  - war & politics
+
+low_payoff_genres:
+  - talk
+  - news
+  - reality
+  - soap
+  - comedy
+
+premium_networks:
+  - hbo
+  - max
+  - apple tv+
+  - netflix
+  - disney+
+  - amazon
+  - prime video
+
+# Hard pins: guardrails enforce these regardless of score or model opinion.
+franchises_2160p:
+  - star wars
+  - dune
+titles_1080p: []
+
+# Per-requester score bias (positive favors 2160p). The key must exactly match
+# the Seerr requestedBy.username on the request (case-sensitive, no
+# normalization) — verify against a shadow decision before trusting it.
+requesters:
+  alexmatthews:
+    bias_2160p: 0.5
+    note: prefers showcase quality for prestige titles
+
+feedback_reason_tags:
+  - showcase
+  - background_watch
+  - storage
+  - prestige_exception
+  - kids_content
+  - rewatch_favorite
+  - bad_metadata

--- a/kubernetes/apps/default/resolute/ks.yaml
+++ b/kubernetes/apps/default/resolute/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: resolute
+spec:
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/default/resolute/app
+  postBuild:
+    substitute:
+      APP: resolute
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: default
+  wait: false


### PR DESCRIPTION
Adds **resolute** (Seerr TV 1080p/2160p decision engine) and **chaski** (Seerr → resolute webhook router) to `apps/default`.

## Flow
Seerr → chaski (verifies inbound `Authorization`) → resolute `POST /api/webhooks/seerr` (verifies `X-Resolute-Token`). Same shared secret both sides (1Password `resolute` → `RESOLUTE_WEBHOOK_SECRET`).

## Verified against resolute source
- ✅ resolute serves `POST /api/webhooks/seerr` and checks the `X-Resolute-Token` header — matches chaski’s forward target/header.
- ✅ resolute serves `/readyz` — matches the readiness probe.
- ✅ resolute refuses to start without `webhook_shared_secret` — so the secret must resolve (see checklist item 1).

## Safety posture (correct for a first deploy)
- `RESOLUTE_MODE: shadow`, `RESOLUTE_ALLOW_WRITES: false`, `RESOLUTE_AUTO_APPROVE_ENABLED: false`, `RESOLUTE_JUDGE__ENABLED: false` — decides/records only, no writes.
- SQLite single-writer respected: 1 replica, `Recreate`, nightly `review-pending` cronjob goes through the API (`--remote`) so the writer/PVC stay put.
- Hardened: `readOnlyRootFilesystem`, `drop: [ALL]`, non-root 1032:100, tmpfs `/tmp`, policy mounted read-only. Image digest-pinned (`:main@sha256:135effa…`).

## Pre-deploy checklist (verify before merging)
1. **1Password fields exist** — `resolute` item needs `RESOLUTE_MODEL_API_KEY`, `RESOLUTE_WEBHOOK_SECRET`, `RESOLUTE_EXECUTE_TOKEN`, `RESOLUTE_API_TOKEN`; `seerr` needs `SEERR_API_KEY`; `sonarr` needs `SONARR_API_KEY`. Any missing field ⇒ ExternalSecret never materializes ⇒ pod won’t start.
2. **Seerr webhook** points at chaski and sends `Authorization: <RESOLUTE_WEBHOOK_SECRET>`.
3. **Sonarr profile names** `WEB-1080p` / `WEB-2160p` match your actual Sonarr quality-profile names exactly.
4. **Image digest** `135effa…` is the `:main` build you intend (switch to `vX.Y.Z` after cutting resolute 0.1.0).

## Optional nits (non-blocking)
- resolute liveness probe is TCP (default); `/healthz` exists if you’d prefer an HTTP liveness.

