### PR TITLE
docs: fix stale README and repo-guide descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,9 @@ diagnostics, Talos operations, and VolSync restore helpers.
 
 ## Operations Docs
 
-- [AI Workbench Prompts](docs/operations/ai-workbench.md) collects starter
-  Hermes and ToolHive MCP prompts.
+- [AI Workbench](docs/operations/ai-workbench.md) is a compact operator note
+  for the Hermes and ToolHive workbench: current surface, boundaries, and the
+  cluster-health triage loop.
 - [Storage and Backups](docs/operations/storage-and-backups.md) describes the
   current backup posture and backup migration criteria.
 

--- a/docs/guides/repo-guide.md
+++ b/docs/guides/repo-guide.md
@@ -10,8 +10,8 @@ commands. Agent behavior and change-control rules live in
   ordering.
 - `.github/actionlint.yaml`: actionlint configuration.
 - `.github/labels.yaml`: label definitions synced by CI.
-- `.github/workflows/`: CI, post-merge render alarm, Renovate, Renovate PR
-  Review, and label sync.
+- `.github/workflows/`: Lint, Image Pull, the post-merge Render alarm,
+  Renovate, Renovate PR Review, and Label Sync.
 - `.mise/config.toml`: repo-pinned tool versions and local environment.
 - `.renovaterc.json5`: Renovate configuration.
 - `bootstrap/`: one-time cluster bootstrap helpers.


### PR DESCRIPTION
## Summary

- README described `docs/operations/ai-workbench.md` as a starter prompt collection; the doc is a compact operator note (surface, boundaries, triage loop). Update the description to match.
- The repo guide's `.github/workflows/` layout line predated the current workflow set; name the actual six workflows (Lint, Image Pull, Render alarm, Renovate, Renovate PR Review, Label Sync).

Docs-only; no manifests or commands changed.

## Validation

- `mise exec --no-deps -- oxfmt --check README.md docs/guides/repo-guide.md`