### PR TITLE
docs: enumerate cluster command boundaries in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,16 @@ small, reviewable, and independently reconcilable.
   direct-to-main edits.
 - Do not make imperative cluster fixes except for diagnostics explicitly
   requested by the user.
+- Read-only cluster inspection counts as diagnostics: `kubectl get`,
+  `describe`, `logs`, `events`, `top`, `auth can-i`, `diff`, and
+  `apply --dry-run=server`, plus the equivalent `flux`, `helm`, and `talosctl`
+  read commands.
+- Treat every mutating cluster command as an imperative fix that needs explicit
+  user approval of the exact action first: `kubectl apply`, `create`, `delete`,
+  `edit`, `patch`, `replace`, `scale`, `rollout`, `annotate`, `label`,
+  `cordon`, `drain`; `flux reconcile`, `suspend`, `resume`; `helm` install,
+  upgrade, or rollback; `talosctl` apply or upgrade; and anything else that
+  changes live state.
 - Do not edit generated outputs, rendered manifests, caches, logs, credentials,
   or local auth/session state.
 - Do not reformat SOPS-encrypted files; their encrypted document shape is


### PR DESCRIPTION
## Summary

The safety boundary "do not make imperative cluster fixes except for diagnostics" stated intent but left agents to classify individual commands. Enumerate the split explicitly: read-only inspection commands that count as diagnostics, and mutating `kubectl`/`flux`/`helm`/`talosctl` commands that always need explicit approval of the exact action.

This clarifies the existing boundary without loosening it; no previously forbidden action becomes allowed.

## Validation

- `mise exec --no-deps -- oxfmt --check AGENTS.md`