### PR TITLE
docs: add add-app agent skill

### DIFF
--- a/.agents/skills/add-app/SKILL.md
+++ b/.agents/skills/add-app/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: add-app
+description: Scaffold a new Flux-managed application under kubernetes/apps/ following this repo's app-template conventions. Use when deploying a new app or service to the cluster.
+---
+
+# Add a New Application
+
+Scaffolds `kubernetes/apps/<namespace>/<app>/` with a Flux Kustomization and a
+bjw-s app-template HelmRelease. Every value below comes from current repo
+conventions. When in doubt, mirror a real app instead of inventing structure:
+
+| Reference app                      | Shows                                                                                               |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `kubernetes/apps/default/atuin`    | Small app: internal route, VolSync-backed PVC, no secrets                                           |
+| `kubernetes/apps/default/resolute` | ExternalSecret, config file via `configMapGenerator`, ServiceMonitor, CronJob, single-writer SQLite |
+| `kubernetes/apps/default/plex`     | Public route on `envoy-external`, Gatus endpoint annotation, LoadBalancer service                   |
+
+## Step 1: Gather details
+
+Confirm with the user anything not already given:
+
+1. **App name** and **namespace** (existing: `ls kubernetes/apps/`). A new
+   namespace is rare; if needed, copy an existing namespace directory's
+   `namespace.yaml` and `kustomization.yaml` shape.
+2. **Image** repository and tag. Pin as `tag@sha256:digest`; Renovate maintains
+   it afterward.
+3. **Port**, and the route posture: none, internal (`envoy-internal`, the
+   default), or public (`envoy-external` — public routes need explicit
+   justification per `AGENTS.md`).
+4. **Persistence**: stateful apps get their PVC from the VolSync component,
+   which also wires backups and requires the Rook-Ceph dependency.
+5. **Secrets**: an ExternalSecret sourced from 1Password. Get the exact item
+   and field names; never guess them.
+6. **Config files**: mounted config uses `configMapGenerator` plus a
+   `resources/` directory (see resolute).
+7. **Dependencies**: other Flux Kustomizations this app needs (`dependsOn`).
+
+## Step 2: Create the files
+
+```text
+kubernetes/apps/<namespace>/<app>/
+├── ks.yaml
+└── app/
+    ├── kustomization.yaml
+    ├── ocirepository.yaml
+    ├── helmrelease.yaml
+    ├── externalsecret.yaml   # only with secrets
+    └── resources/            # only with config files
+```
+
+### ks.yaml
+
+Copy atuin's `ks.yaml`. Keep the key order and drop what does not apply:
+
+- `components` + `dependsOn` (rook-ceph-cluster): only with a VolSync PVC.
+- `postBuild.substitute.APP` is required by the VolSync component; add
+  `VOLSYNC_CAPACITY` when the component default (5Gi) is wrong.
+- `postBuild.substituteFrom: cluster-secrets`: needed for `${SECRET_DOMAIN}`
+  and other substituted values.
+- `targetNamespace` matches the namespace directory.
+
+### app/kustomization.yaml
+
+Copy atuin's. Resources are listed alphabetically. With config files, add the
+generator (see resolute):
+
+```yaml
+configMapGenerator:
+    - name: <app>-config
+      files:
+          - ./resources/<file>
+generatorOptions:
+    disableNameSuffixHash: true
+```
+
+### app/ocirepository.yaml
+
+Copy atuin's. The chart is `oci://ghcr.io/bjw-s-labs/helm/app-template`; use
+the same chart tag as nearby apps (Renovate bumps it).
+
+### app/helmrelease.yaml
+
+Copy atuin's and adapt. Invariants to keep:
+
+- Schema comment pointing at the app-template helmrelease schema.
+- `spec.values` order: `controllers`, `defaultPodOptions`, `service`, `route`,
+  `configMaps`, `persistence` (see
+  `.agents/instructions/yaml-ordering.instructions.md`).
+- `defaultPodOptions.securityContext` for stateful apps: `runAsNonRoot: true`,
+  `runAsUser: 1032`, `runAsGroup: 100`, `fsGroup: 100`,
+  `fsGroupChangePolicy: OnRootMismatch`. Do not invent new identities; see
+  `docs/operations/storage-and-backups.md` before deviating.
+- Container `securityContext`: `allowPrivilegeEscalation: false`,
+  `readOnlyRootFilesystem: true`, `capabilities: { drop: ["ALL"] }`. Add an
+  `emptyDir` at `/tmp` if the app needs scratch space (see resolute).
+- Liveness, readiness, and startup probes like atuin; use a custom `httpGet`
+  readiness probe when the app has a health endpoint.
+- `resources`: `requests.cpu: 10m` and a memory limit sized to the app.
+- Route hostnames use `"{{ .Release.Name }}.${SECRET_DOMAIN}"`; never hardcode
+  the domain. Public routes get a Gatus endpoint annotation (see plex).
+- VolSync persistence mounts `existingClaim: "{{ .Release.Name }}"`.
+- Secrets arrive via `envFrom` from `"{{ .Release.Name }}-secret"`, with
+  `reloader.stakater.com/auto: "true"` on the controller.
+- SQLite or other single-writer apps: `replicas: 1` with
+  `strategy: Recreate`, and a comment saying not to scale (see resolute).
+
+### app/externalsecret.yaml
+
+Copy resolute's shape: `ClusterSecretStore` `onepassword-connect`, a
+`target.template.data` map from 1Password fields to the env names the app
+expects, and `dataFrom.extract` per 1Password item.
+
+## Step 3: Register the app
+
+Add `./<app>/ks.yaml` to `kubernetes/apps/<namespace>/kustomization.yaml`,
+keeping the list alphabetical.
+
+## Step 4: Validate
+
+```sh
+mise exec -- kubectl kustomize kubernetes/apps/<namespace>/<app>/app
+mise exec -- flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets
+mise exec -- flate diff images -p ./kubernetes/flux/cluster -o json
+mise exec --no-deps -- oxfmt --check <changed files>
+```
+
+The image diff should list exactly the new app's image. Open the change as a
+PR branch; Konflate posts the rendered diff on the PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@ small, reviewable, and independently reconcilable.
   edits.
 - `.agents/instructions/` is reserved for narrow reusable instructions such as
   YAML ordering. Load only the files relevant to the task.
+- `.agents/skills/` holds task recipes such as `add-app`. Load a skill only
+  when performing that task.
 - `backlog.md`, if present, is scratch state.
 
 ## Before Editing


### PR DESCRIPTION
## Summary

Add `.agents/skills/add-app/SKILL.md`, a task recipe for scaffolding a new Flux-managed app, and register `.agents/skills/` in the AGENTS.md entry points.

The skill is derived from this repo's own manifests rather than copied from peers: atuin (minimal app with VolSync PVC and internal route), resolute (ExternalSecret, configMapGenerator, ServiceMonitor, single-writer), and plex (public route with Gatus annotation) are the reference apps. To limit drift it points at those files and lists the invariants to keep (security context identity, probes, `${SECRET_DOMAIN}` hostnames, VolSync claim shape, single-writer rules) instead of duplicating full manifests.

No symlink or harness-specific discovery wiring; the skill is loaded on demand via the AGENTS.md pointer.

## Validation

- `mise exec --no-deps -- oxfmt --check .agents/skills/add-app/SKILL.md AGENTS.md`
- Reference paths and conventions checked against the current manifests they cite.