### PR TITLE
docs: correct overgeneralized and stale agent-doc claims

### DIFF
--- a/.agents/skills/add-app/SKILL.md
+++ b/.agents/skills/add-app/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: add-app
-description: Scaffold a new Flux-managed application under kubernetes/apps/ following this repo's app-template conventions. Use when deploying a new app or service to the cluster.
+description: Scaffold a new Flux-managed application under kubernetes/apps/ — chart selection, manifests, registration, validation. Use when deploying a new app or service to the cluster.
 ---
 
 # Add a New Application
 
 Scaffolds `kubernetes/apps/<namespace>/<app>/` with a Flux Kustomization and a
-bjw-s app-template HelmRelease. Every value below comes from current repo
-conventions. When in doubt, mirror a real app instead of inventing structure:
+HelmRelease (chart chosen in Step 0). Every value below comes from current
+repo conventions. When in doubt, mirror a real app instead of inventing
+structure:
 
-| Reference app                      | Shows                                                                                               |
-| ---------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `kubernetes/apps/default/atuin`    | Small app: internal route, VolSync-backed PVC, no secrets                                           |
-| `kubernetes/apps/default/resolute` | ExternalSecret, config file via `configMapGenerator`, ServiceMonitor, CronJob, single-writer SQLite |
-| `kubernetes/apps/default/plex`     | Public route on `envoy-external`, Gatus endpoint annotation, LoadBalancer service                   |
+| Reference app                       | Shows                                                                                       |
+| ----------------------------------- | ------------------------------------------------------------------------------------------- |
+| `kubernetes/apps/default/atuin`     | Small app: internal route, VolSync-backed PVC, no secrets                                   |
+| `kubernetes/apps/default/recyclarr` | Config files via `configMapGenerator` + `resources/`                                        |
+| `kubernetes/apps/default/resolute`  | ExternalSecret, SOPS-encrypted config Secret, ServiceMonitor, CronJob, single-writer SQLite |
+| `kubernetes/apps/default/plex`      | Public route on `envoy-external`, Gatus endpoint annotation, LoadBalancer service           |
 
 ## Step 0: Pick the chart
 
@@ -43,7 +45,9 @@ Confirm with the user anything not already given:
 5. **Secrets**: an ExternalSecret sourced from 1Password. Get the exact item
    and field names; never guess them.
 6. **Config files**: mounted config uses `configMapGenerator` plus a
-   `resources/` directory (see resolute).
+   `resources/` directory (see recyclarr). Config carrying household identity
+   or other sensitive values goes into a SOPS-encrypted Secret instead (see
+   resolute's `secret.sops.yaml`).
 7. **Dependencies**: other Flux Kustomizations this app needs (`dependsOn`).
 
 ## Step 2: Create the files
@@ -72,17 +76,9 @@ Copy atuin's `ks.yaml`. Keep the key order and drop what does not apply:
 
 ### app/kustomization.yaml
 
-Copy atuin's. Resources are listed alphabetically. With config files, add the
-generator (see resolute):
-
-```yaml
-configMapGenerator:
-    - name: <app>-config
-      files:
-          - ./resources/<file>
-generatorOptions:
-    disableNameSuffixHash: true
-```
+Copy atuin's. Resources are listed alphabetically. With config files, copy
+recyclarr's `configMapGenerator` block (name `<app>-configmap`, one entry per
+`resources/` file, `disableNameSuffixHash: true`).
 
 ### app/ocirepository.yaml
 
@@ -112,6 +108,9 @@ Copy atuin's and adapt. Invariants to keep:
 - Route hostnames use `"{{ .Release.Name }}.${SECRET_DOMAIN}"`; never hardcode
   the domain. Public routes get a Gatus endpoint annotation (see plex).
 - VolSync persistence mounts `existingClaim: "{{ .Release.Name }}"`.
+- Config files mount as `type: configMap` with
+  `name: "{{ .Release.Name }}-configmap"` (see recyclarr); SOPS-encrypted
+  config mounts as `type: secret` (see resolute).
 - Secrets arrive via `envFrom` from `"{{ .Release.Name }}-secret"`, with
   `reloader.stakater.com/auto: "true"` on the controller.
 - SQLite or other single-writer apps: `replicas: 1` with
@@ -119,9 +118,11 @@ Copy atuin's and adapt. Invariants to keep:
 
 ### app/externalsecret.yaml
 
-Copy resolute's shape: `ClusterSecretStore` `onepassword-connect`, a
-`target.template.data` map from 1Password fields to the env names the app
-expects, and `dataFrom.extract` per 1Password item.
+Copy the first document in resolute's `externalsecret.yaml` (the file holds a
+second, scoped ExternalSecret for its CronJob — most apps need only one):
+`ClusterSecretStore` `onepassword-connect`, a `target.template.data` map from
+1Password fields to the env names the app expects, and `dataFrom.extract` per
+1Password item.
 
 ## Step 3: Register the app
 

--- a/.agents/skills/add-app/SKILL.md
+++ b/.agents/skills/add-app/SKILL.md
@@ -15,6 +15,17 @@ conventions. When in doubt, mirror a real app instead of inventing structure:
 | `kubernetes/apps/default/resolute` | ExternalSecret, config file via `configMapGenerator`, ServiceMonitor, CronJob, single-writer SQLite |
 | `kubernetes/apps/default/plex`     | Public route on `envoy-external`, Gatus endpoint annotation, LoadBalancer service                   |
 
+## Step 0: Pick the chart
+
+If the app has a maintained upstream chart or a home-operations chart, use
+that chart instead of app-template: mirror an existing upstream-chart app such
+as `kubernetes/apps/default/chaski` or
+`kubernetes/apps/observability/gatus-sidecar`, follow the chart's own values
+order, and skip the app-template specifics below.
+
+The rest of this skill covers the common case for self-hosted apps: a
+container image with no maintained chart, deployed via bjw-s app-template.
+
 ## Step 1: Gather details
 
 Confirm with the user anything not already given:
@@ -86,10 +97,12 @@ Copy atuin's and adapt. Invariants to keep:
 - `spec.values` order: `controllers`, `defaultPodOptions`, `service`, `route`,
   `configMaps`, `persistence` (see
   `.agents/instructions/yaml-ordering.instructions.md`).
-- `defaultPodOptions.securityContext` for stateful apps: `runAsNonRoot: true`,
-  `runAsUser: 1032`, `runAsGroup: 100`, `fsGroup: 100`,
-  `fsGroupChangePolicy: OnRootMismatch`. Do not invent new identities; see
-  `docs/operations/storage-and-backups.md` before deviating.
+- `defaultPodOptions.securityContext` for VolSync-backed apps only:
+  `runAsNonRoot: true`, `runAsUser: 1032`, `runAsGroup: 100`, `fsGroup: 100`,
+  `fsGroupChangePolicy: OnRootMismatch` — the identity the Restic movers and
+  the NAS convention expect (`docs/operations/storage-and-backups.md`). Apps
+  without VolSync persistence run whatever identity their image expects; keep
+  `runAsNonRoot: true` where the image allows it.
 - Container `securityContext`: `allowPrivilegeEscalation: false`,
   `readOnlyRootFilesystem: true`, `capabilities: { drop: ["ALL"] }`. Add an
   `emptyDir` at `/tmp` if the app needs scratch space (see resolute).

--- a/docs/guides/repo-guide.md
+++ b/docs/guides/repo-guide.md
@@ -61,10 +61,10 @@ restore-capable `dataSourceRef`, an hourly local Restic `ReplicationSource`,
 and a daily remote one. Details and restore drills live in
 [`../operations/storage-and-backups.md`](../operations/storage-and-backups.md).
 
-Workload identity defaults to `runAsUser: 1032` / `runAsGroup: 100` /
-`fsGroup: 100` for app pods and their VolSync movers, matching the NAS-side
-convention. Do not change an app's identity without migrating PVC ownership in
-the same window.
+VolSync-backed apps run as `runAsUser: 1032` / `runAsGroup: 100` /
+`fsGroup: 100`, matching their Restic movers and the NAS-side convention;
+other apps run whatever identity their image expects. Do not change a
+backed-up app's identity without migrating PVC ownership in the same window.
 
 Stateful apps run a single replica (the chart default; most set no explicit
 `replicas` or `strategy`), and their `ReadWriteOnce` PVCs would not tolerate


### PR DESCRIPTION
## Summary

Two corrections to guidance merged earlier today, both overgeneralizations:

- The `1032:100` security context was presented as the default for "stateful apps". It is the convention for VolSync-backed apps specifically: the 19 apps setting `runAsUser: 1032` are exactly the 19 apps using the VolSync component, while non-VolSync apps run 1000, 64535, or the image default. Both the add-app skill and the repo guide now scope the identity to VolSync-backed apps and say other apps run what their image expects.
- The add-app skill assumed app-template unconditionally. Added a "Step 0: pick the chart" gate: maintained upstream or home-operations charts take precedence (mirror chaski / gatus-sidecar); app-template is the path for container images with no maintained chart.

Docs-only.

## Validation

- `mise exec --no-deps -- oxfmt --check .agents/skills/add-app/SKILL.md docs/guides/repo-guide.md`
- Identity claim cross-checked: `runAsUser: 1032` app set matches the `components/volsync` app set 1:1.