### PR TITLE
docs: correct component coverage and resource claims from re-audit

### DIFF
--- a/.agents/skills/add-app/SKILL.md
+++ b/.agents/skills/add-app/SKILL.md
@@ -104,7 +104,9 @@ Copy atuin's and adapt. Invariants to keep:
   `emptyDir` at `/tmp` if the app needs scratch space (see resolute).
 - Liveness, readiness, and startup probes like atuin; use a custom `httpGet`
   readiness probe when the app has a health endpoint.
-- `resources`: `requests.cpu: 10m` and a memory limit sized to the app.
+- `resources`: start at `requests.cpu: 10m` with a memory limit sized to the
+  app; heavier apps in this repo run `100m`, so match a comparable app rather
+  than the minimum.
 - Route hostnames use `"{{ .Release.Name }}.${SECRET_DOMAIN}"`; never hardcode
   the domain. Public routes get a Gatus endpoint annotation (see plex).
 - VolSync persistence mounts `existingClaim: "{{ .Release.Name }}"`.

--- a/docs/guides/repo-guide.md
+++ b/docs/guides/repo-guide.md
@@ -8,6 +8,7 @@ commands. Agent behavior and change-control rules live in
 
 - `.agents/instructions/`: narrow reusable agent instructions, currently YAML
   ordering.
+- `.agents/skills/`: task recipes, currently `add-app`.
 - `.github/actionlint.yaml`: actionlint configuration.
 - `.github/labels.yaml`: label definitions synced by CI.
 - `.github/workflows/`: Lint, Image Pull, the post-merge Render alarm,
@@ -37,7 +38,8 @@ How a merged change reaches the cluster:
    every child Kustomization with the same decryption and HelmRelease
    remediation defaults.
 3. Each namespace directory's `kustomization.yaml` creates the Namespace, adds
-   shared components such as alerts and SOPS, and lists every app `ks.yaml`.
+   the shared alerts component (all namespaces) and the SOPS component (only
+   namespaces that need `cluster-secrets`), and lists every app `ks.yaml`.
 4. Each app `ks.yaml` is a Flux Kustomization that renders the app's `app/`
    directory into the target namespace.
 
@@ -51,15 +53,17 @@ Secrets reach workloads through two mechanisms:
   workload consumes via `envFrom` or `env`. Secret material never appears in
   Git.
 - Build-time substitution: the SOPS component ships an age-encrypted
-  `cluster-secrets` Secret into each namespace. App `ks.yaml` files opt in with
+  `cluster-secrets` Secret into the namespaces that include the component —
+  not all do. App `ks.yaml` files opt in with
   `postBuild.substituteFrom: cluster-secrets`, which fills
   `${SECRET_DOMAIN}`-style placeholders when Flux builds the app.
 
 Stateful apps normally get their PVC from the VolSync component
 (`kubernetes/components/volsync`): a `${APP}` claim on `ceph-block` with a
 restore-capable `dataSourceRef`, an hourly local Restic `ReplicationSource`,
-and a daily remote one. Details and restore drills live in
-[`../operations/storage-and-backups.md`](../operations/storage-and-backups.md).
+and a daily remote one. Backup topology and restore criteria live in
+[`../operations/storage-and-backups.md`](../operations/storage-and-backups.md);
+restore templates live under `volsync/`.
 
 VolSync-backed apps run as `runAsUser: 1032` / `runAsGroup: 100` /
 `fsGroup: 100`, matching their Restic movers and the NAS-side convention;


### PR DESCRIPTION
## Summary

Follow-up corrections from a full re-audit of the agent-facing docs, checking claim scope against manifests (same error class as the identity/Recreate fixes in #1483):

- Repo guide said the SOPS component ships `cluster-secrets` "into each namespace" — only the namespaces that include the component get it (half do not). Reworded, without a hardcoded count that would drift.
- The reconciliation-flow step implied alerts and SOPS are both standard namespace components; alerts is universal, SOPS is opt-in. Now stated precisely.
- Layout list gained the `.agents/skills/` entry that #1481 introduced but never listed.
- "Restore drills live in storage-and-backups.md" overstated the doc; it records topology and criteria, with restore templates under `volsync/`.
- The add-app skill presented `requests.cpu: 10m` as the rule; a third of comparable apps run `100m`. Now framed as a starting point with "match a comparable app".

Everything else in AGENTS.md, the repo guide, the skill, the YAML-ordering instructions, README, and the operations docs was re-verified against manifests and checks out (Flux sync path/branch, VolSync schedules, sibling-directory list, ExternalSecret naming, MCP tool list, privileged-movers note, node count).

Docs-only.

## Validation

- `mise exec --no-deps -- oxfmt --check docs/guides/repo-guide.md .agents/skills/add-app/SKILL.md`
- Each corrected claim cross-checked by grep against current manifests.