### PR TITLE
feat(grafana): add resolute shadow-mode dashboard

### DIFF
--- a/kubernetes/apps/observability/grafana/dashboards/home-ops/resolute.yaml
+++ b/kubernetes/apps/observability/grafana/dashboards/home-ops/resolute.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: resolute
+  labels:
+    dashboards: grafana
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  folderRef: home-ops
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  configMapRef:
+    name: resolute-dashboard
+    key: resolute.json

--- a/kubernetes/apps/observability/grafana/dashboards/home-ops/resources/resolute.json
+++ b/kubernetes/apps/observability/grafana/dashboards/home-ops/resources/resolute.json
@@ -1,0 +1,249 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": { "limit": 100, "matchAny": false, "tags": [], "type": "dashboard" },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Must stay 0 while resolute runs in shadow mode. Any non-zero value means a write executed and needs immediate investigation. Counters reset on pod restart.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(resolute_executions_total) or vector(0)",
+          "legendFormat": "executions",
+          "refId": "A"
+        }
+      ],
+      "title": "Executions (shadow mode: must be 0)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Execution failures. Should also be 0 in shadow mode.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(resolute_execution_failures_total) or vector(0)",
+          "legendFormat": "failures",
+          "refId": "A"
+        }
+      ],
+      "title": "Execution failures",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Decision mix over the dashboard time range. The core shadow-mode signal: how often the engine picks 2160p, 1080p, or lands in the ambiguous band.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "hideFrom": { "legend": false, "tooltip": false, "viz": false } },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 0 },
+      "id": 3,
+      "options": {
+        "displayLabels": ["name", "value"],
+        "legend": { "displayMode": "list", "placement": "right", "showLegend": true },
+        "pieType": "pie",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (resolution) (increase(resolute_decisions_total[$__range]))",
+          "legendFormat": "{{ resolution }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Decision mix",
+      "type": "piechart"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Decisions per hour by resolution. Counters are in-memory and reset on pod restart; rate() handles the resets.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "normal" }
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "id": 4,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (resolution) (rate(resolute_decisions_total[$__rate_interval])) * 3600",
+          "legendFormat": "{{ resolution }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Decision rate (per hour)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Webhook outcomes per hour. Unauthorized, invalid, and skipped should stay near 0; sustained non-zero values point at Seerr webhook config or auth drift.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(resolute_webhook_decided_total[$__rate_interval])) * 3600",
+          "legendFormat": "decided",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(resolute_webhook_unauthorized_total[$__rate_interval])) * 3600",
+          "legendFormat": "unauthorized",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(resolute_webhook_skipped_total[$__rate_interval])) * 3600",
+          "legendFormat": "skipped",
+          "refId": "C"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(resolute_webhook_invalid_total[$__rate_interval])) * 3600",
+          "legendFormat": "invalid",
+          "refId": "D"
+        }
+      ],
+      "title": "Webhook health (per hour)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 41,
+  "tags": ["resolute", "home-ops"],
+  "templating": { "list": [] },
+  "time": { "from": "now-7d", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Resolute (shadow mode)",
+  "uid": "resolute-shadow",
+  "version": 1
+}

--- a/kubernetes/apps/observability/grafana/dashboards/home-ops/resources/resolute.json
+++ b/kubernetes/apps/observability/grafana/dashboards/home-ops/resources/resolute.json
@@ -30,7 +30,7 @@
   "panels": [
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "description": "Must stay 0 while resolute runs in shadow mode. Any non-zero value means a write executed and needs immediate investigation. Counters reset on pod restart.",
+      "description": "Executions within the dashboard time range. Must stay 0 while resolute runs in shadow mode; any non-zero value means a write executed and needs immediate investigation. increase() absorbs counter resets from pod restarts inside the range; events before the range are not shown, so widen the range when auditing history.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
@@ -61,7 +61,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(resolute_executions_total) or vector(0)",
+          "expr": "sum(increase(resolute_executions_total{job=\"resolute\", namespace=\"default\"}[$__range]))",
           "legendFormat": "executions",
           "refId": "A"
         }
@@ -71,7 +71,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "description": "Execution failures. Should also be 0 in shadow mode.",
+      "description": "Execution failures within the dashboard time range. Should also be 0 in shadow mode.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
@@ -102,7 +102,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(resolute_execution_failures_total) or vector(0)",
+          "expr": "sum(increase(resolute_execution_failures_total{job=\"resolute\", namespace=\"default\"}[$__range]))",
           "legendFormat": "failures",
           "refId": "A"
         }
@@ -135,7 +135,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum by (resolution) (increase(resolute_decisions_total[$__range]))",
+          "expr": "sum by (resolution) (increase(resolute_decisions_total{job=\"resolute\", namespace=\"default\"}[$__range]))",
           "legendFormat": "{{ resolution }}",
           "refId": "A"
         }
@@ -172,7 +172,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum by (resolution) (rate(resolute_decisions_total[$__rate_interval])) * 3600",
+          "expr": "sum by (resolution) (rate(resolute_decisions_total{job=\"resolute\", namespace=\"default\"}[$__rate_interval])) * 3600",
           "legendFormat": "{{ resolution }}",
           "refId": "A"
         }
@@ -209,25 +209,25 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(rate(resolute_webhook_decided_total[$__rate_interval])) * 3600",
+          "expr": "sum(rate(resolute_webhook_decided_total{job=\"resolute\", namespace=\"default\"}[$__rate_interval])) * 3600",
           "legendFormat": "decided",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(rate(resolute_webhook_unauthorized_total[$__rate_interval])) * 3600",
+          "expr": "sum(rate(resolute_webhook_unauthorized_total{job=\"resolute\", namespace=\"default\"}[$__rate_interval])) * 3600",
           "legendFormat": "unauthorized",
           "refId": "B"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(rate(resolute_webhook_skipped_total[$__rate_interval])) * 3600",
+          "expr": "sum(rate(resolute_webhook_skipped_total{job=\"resolute\", namespace=\"default\"}[$__rate_interval])) * 3600",
           "legendFormat": "skipped",
           "refId": "C"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(rate(resolute_webhook_invalid_total[$__rate_interval])) * 3600",
+          "expr": "sum(rate(resolute_webhook_invalid_total{job=\"resolute\", namespace=\"default\"}[$__rate_interval])) * 3600",
           "legendFormat": "invalid",
           "refId": "D"
         }

--- a/kubernetes/apps/observability/grafana/dashboards/home-ops/resources/resolute.json
+++ b/kubernetes/apps/observability/grafana/dashboards/home-ops/resources/resolute.json
@@ -29,7 +29,7 @@
   "links": [],
   "panels": [
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": { "type": "prometheus", "uid": "$${DS_PROMETHEUS}" },
       "description": "Executions within the dashboard time range. Must stay 0 while resolute runs in shadow mode; any non-zero value means a write executed and needs immediate investigation. increase() absorbs counter resets from pod restarts inside the range; events before the range are not shown, so widen the range when auditing history.",
       "fieldConfig": {
         "defaults": {
@@ -60,9 +60,11 @@
       "pluginVersion": "12.0.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(increase(resolute_executions_total{job=\"resolute\", namespace=\"default\"}[$__range]))",
+          "datasource": { "type": "prometheus", "uid": "$${DS_PROMETHEUS}" },
+          "expr": "sum(increase(resolute_executions_total{job=\"resolute\", namespace=\"default\"}[$__range])) or vector(0)",
+          "instant": true,
           "legendFormat": "executions",
+          "range": false,
           "refId": "A"
         }
       ],
@@ -70,7 +72,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": { "type": "prometheus", "uid": "$${DS_PROMETHEUS}" },
       "description": "Execution failures within the dashboard time range. Should also be 0 in shadow mode.",
       "fieldConfig": {
         "defaults": {
@@ -101,9 +103,11 @@
       "pluginVersion": "12.0.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(increase(resolute_execution_failures_total{job=\"resolute\", namespace=\"default\"}[$__range]))",
+          "datasource": { "type": "prometheus", "uid": "$${DS_PROMETHEUS}" },
+          "expr": "sum(increase(resolute_execution_failures_total{job=\"resolute\", namespace=\"default\"}[$__range])) or vector(0)",
+          "instant": true,
           "legendFormat": "failures",
+          "range": false,
           "refId": "A"
         }
       ],
@@ -111,7 +115,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": { "type": "prometheus", "uid": "$${DS_PROMETHEUS}" },
       "description": "Decision mix over the dashboard time range. The core shadow-mode signal: how often the engine picks 2160p, 1080p, or lands in the ambiguous band.",
       "fieldConfig": {
         "defaults": {
@@ -134,9 +138,11 @@
       "pluginVersion": "12.0.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "$${DS_PROMETHEUS}" },
           "expr": "sum by (resolution) (increase(resolute_decisions_total{job=\"resolute\", namespace=\"default\"}[$__range]))",
+          "instant": true,
           "legendFormat": "{{ resolution }}",
+          "range": false,
           "refId": "A"
         }
       ],
@@ -144,7 +150,7 @@
       "type": "piechart"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": { "type": "prometheus", "uid": "$${DS_PROMETHEUS}" },
       "description": "Decisions per hour by resolution. Counters are in-memory and reset on pod restart; rate() handles the resets.",
       "fieldConfig": {
         "defaults": {
@@ -171,7 +177,7 @@
       "pluginVersion": "12.0.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "$${DS_PROMETHEUS}" },
           "expr": "sum by (resolution) (rate(resolute_decisions_total{job=\"resolute\", namespace=\"default\"}[$__rate_interval])) * 3600",
           "legendFormat": "{{ resolution }}",
           "refId": "A"
@@ -181,7 +187,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": { "type": "prometheus", "uid": "$${DS_PROMETHEUS}" },
       "description": "Webhook outcomes per hour. Unauthorized, invalid, and skipped should stay near 0; sustained non-zero values point at Seerr webhook config or auth drift.",
       "fieldConfig": {
         "defaults": {
@@ -208,25 +214,25 @@
       "pluginVersion": "12.0.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "$${DS_PROMETHEUS}" },
           "expr": "sum(rate(resolute_webhook_decided_total{job=\"resolute\", namespace=\"default\"}[$__rate_interval])) * 3600",
           "legendFormat": "decided",
           "refId": "A"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "$${DS_PROMETHEUS}" },
           "expr": "sum(rate(resolute_webhook_unauthorized_total{job=\"resolute\", namespace=\"default\"}[$__rate_interval])) * 3600",
           "legendFormat": "unauthorized",
           "refId": "B"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "$${DS_PROMETHEUS}" },
           "expr": "sum(rate(resolute_webhook_skipped_total{job=\"resolute\", namespace=\"default\"}[$__rate_interval])) * 3600",
           "legendFormat": "skipped",
           "refId": "C"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": { "type": "prometheus", "uid": "$${DS_PROMETHEUS}" },
           "expr": "sum(rate(resolute_webhook_invalid_total{job=\"resolute\", namespace=\"default\"}[$__rate_interval])) * 3600",
           "legendFormat": "invalid",
           "refId": "D"

--- a/kubernetes/apps/observability/grafana/dashboards/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana/dashboards/kustomization.yaml
@@ -5,10 +5,14 @@ kind: Kustomization
 resources:
   - ./folders/home-ops.yaml
   - ./home-ops/home-ops-cockpit.yaml
+  - ./home-ops/resolute.yaml
 configMapGenerator:
   - name: home-ops-cockpit-dashboard
     files:
       - home-ops-cockpit.json=./home-ops/resources/home-ops-cockpit.json
+  - name: resolute-dashboard
+    files:
+      - resolute.json=./home-ops/resources/resolute.json
 generatorOptions:
   disableNameSuffixHash: true
   labels:


### PR DESCRIPTION
## Summary

Add the resolute shadow-mode observability dashboard from #1445, following the grafana-operator convention (GrafanaDashboard CR + configMapGenerator into the `home-ops` folder, `DS_PROMETHEUS` input mapping like the cockpit dashboard).

Panels:

- **Executions / execution failures** — instant stat panels over the dashboard time range using `increase(...[$__range])` with an `or vector(0)` fallback so lazily-absent counters render as a true zero-valued series, red on any non-zero value. `increase()` absorbs in-range counter resets from pod restarts; events before the selected range require widening the range.
- **Decision mix** — instant pie of `increase(resolute_decisions_total[$__range])` by `resolution`.
- **Decision rate** — stacked per-hour `rate()` by resolution.
- **Webhook health** — decided vs unauthorized / skipped / invalid per hour via `rate()`.

Every query is scoped to the verified scrape target `{job="resolute", namespace="default"}` (labels confirmed against live Prometheus, not assumed). Datasource UIDs are written as `$${DS_PROMETHEUS}` because the `grafana-dashboards` Flux Kustomization runs post-build substitution — the escape collapses to the literal `${DS_PROMETHEUS}` placeholder Grafana Operator expects, matching the cockpit dashboard.

No alerting resources are included; whether a non-zero shadow-mode execution should page is a separate decision.

Closes #1445.

## Validation

- JSON parses; `kubectl kustomize` renders the CR + ConfigMap.
- Flux substitution simulated end-to-end: `kubectl kustomize ... | flux envsubst` — the rendered ConfigMap retains the literal `${DS_PROMETHEUS}` in all 13 positions with no empty `uid` fields.
- All 8 PromQL expressions evaluated against live Prometheus (`$__range`→1h, `$__rate_interval`→5m): all `success`. The two execution stat queries return an actual `0`-valued series via the `or vector(0)` fallback; `resolute_webhook_skipped_total` returns live data confirming label scoping. The remaining families are lazily absent, so those queries are syntax- and label-validated but not yet exercised against data.
- `mise exec -- flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets` — 206 passed.
- `mise exec --no-deps -- oxfmt --check` on the JSON.