### PR TITLE
docs: correct secret paths, persistence scope, RWO semantics, and backup inventory

### DIFF
--- a/.agents/skills/add-app/SKILL.md
+++ b/.agents/skills/add-app/SKILL.md
@@ -42,14 +42,22 @@ Confirm with the user anything not already given:
 3. **Port**, and the route posture: none, internal (`envoy-internal`, the
    default), or public (`envoy-external` — public routes need explicit
    justification per `AGENTS.md`).
-4. **Persistence**: stateful apps get their PVC from the VolSync component,
-   which also wires backups and requires the Rook-Ceph dependency.
+4. **Persistence**: choose backup posture from the app's value and recovery
+   requirements, not from the presence of a PVC. Protected application state
+   (the norm in the `default` namespace) uses the VolSync component, which
+   wires backups and requires the Rook-Ceph dependency. Some persistent
+   workloads — observability data especially — intentionally use plain PVCs
+   with no VolSync; do not add VolSync coverage just because the app is
+   stateful.
 5. **Secrets**: an ExternalSecret sourced from 1Password. Get the exact item
    and field names; never guess them.
 6. **Config files**: mounted config uses `configMapGenerator` plus a
-   `resources/` directory (see recyclarr). Config carrying household identity
-   or other sensitive values goes into a SOPS-encrypted Secret instead (see
-   resolute's `secret.sops.yaml`).
+   `resources/` directory (see recyclarr). A structured config file that
+   mixes sensitive and non-sensitive content and cannot cleanly split into
+   ExternalSecret fields may be committed as a directly SOPS-encrypted Secret
+   instead (see resolute's `secret.sops.yaml`) — that is an exception, not
+   the default. Ordinary credentials always go through
+   1Password/ExternalSecret; never encrypt them directly into Git.
 7. **Dependencies**: other Flux Kustomizations this app needs (`dependsOn`).
 
 ## Step 2: Create the files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,14 @@ small, reviewable, and independently reconcilable.
   `cordon`, `drain`; `flux reconcile`, `suspend`, `resume`; `helm` install,
   upgrade, or rollback; `talosctl` apply or upgrade; and anything else that
   changes live state.
+- Classify `kubectl exec`, `port-forward`, `cp`, and `debug` by behavior, not
+  name. Acceptable diagnostics: exec'ing a strictly read-only command in an
+  existing pod, or a short-lived local port-forward to inspect an internal
+  endpoint. Ask first for anything that changes state: exec'ing commands that
+  write files or run repairs, `kubectl cp` into a pod, and `kubectl debug`,
+  which creates debug workloads. Copying out of a pod is state-preserving but
+  can extract data — state the reason before copying anything out, and never
+  use exec, cp, or port-forward to read or move secret material.
 - Do not edit generated outputs, rendered manifests, caches, logs, credentials,
   or local auth/session state.
 - Do not reformat SOPS-encrypted files; their encrypted document shape is

--- a/docs/guides/repo-guide.md
+++ b/docs/guides/repo-guide.md
@@ -46,22 +46,33 @@ How a merged change reaches the cluster:
 Nothing reaches the cluster except through this path. Imperative changes are
 diagnostics-only; Flux overwrites drift on the next reconcile.
 
-Secrets reach workloads through two mechanisms:
+Secrets reach workloads through three mechanisms; pick by data shape:
 
-- Runtime secrets: 1Password → onepassword-connect → the `onepassword-connect`
-  `ClusterSecretStore` → a per-app `ExternalSecret` → a Kubernetes Secret the
-  workload consumes via `envFrom` or `env`. Secret material never appears in
-  Git.
-- Build-time substitution: the SOPS component ships an age-encrypted
-  `cluster-secrets` Secret into the namespaces that include the component —
-  not all do. App `ks.yaml` files opt in with
+- Ordinary runtime credentials (API keys, passwords, tokens): 1Password →
+  onepassword-connect → the `onepassword-connect` `ClusterSecretStore` → a
+  per-app `ExternalSecret` → a Kubernetes Secret the workload consumes via
+  `envFrom` or `env`. This is the default for anything credential-shaped;
+  secret material never appears in Git.
+- Build-time substitution for non-credential values: the SOPS component ships
+  an age-encrypted `cluster-secrets` Secret into the namespaces that include
+  the component — not all do. App `ks.yaml` files opt in with
   `postBuild.substituteFrom: cluster-secrets`, which fills
   `${SECRET_DOMAIN}`-style placeholders when Flux builds the app.
+- Exception for indivisible structured files: a config file that mixes
+  sensitive and non-sensitive content and cannot cleanly split into
+  ExternalSecret fields may be committed as a directly SOPS-encrypted Secret
+  in the app directory and mounted as a file (resolute's `secret.sops.yaml`
+  household policy is the one current example). Do not use this path for
+  ordinary credentials; those belong in 1Password.
 
-Stateful apps normally get their PVC from the VolSync component
+Backup posture is chosen from an app's value and recovery requirements, not
+from the presence of a PVC. Protected application state — the norm in the
+`default` namespace — gets its PVC from the VolSync component
 (`kubernetes/components/volsync`): a `${APP}` claim on `ceph-block` with a
 restore-capable `dataSourceRef`, an hourly local Restic `ReplicationSource`,
-and a daily remote one. Backup topology and restore criteria live in
+and a daily remote one. Some persistent workloads, notably observability
+storage, intentionally use plain PVCs with no VolSync coverage. Backup
+topology and restore criteria live in
 [`../operations/storage-and-backups.md`](../operations/storage-and-backups.md);
 restore templates live under `volsync/`.
 
@@ -70,12 +81,16 @@ VolSync-backed apps run as `runAsUser: 1032` / `runAsGroup: 100` /
 other apps run whatever identity their image expects. Do not change a
 backed-up app's identity without migrating PVC ownership in the same window.
 
-Stateful apps run a single replica (the chart default; most set no explicit
-`replicas` or `strategy`), and their `ReadWriteOnce` PVCs would not tolerate
-scaling anyway. resolute is additionally single-writer by its own design
-(SQLite allows one writer): it pins `replicas: 1` with `strategy: Recreate`,
-routes writes through the one API pod, and must never be scaled. That
-constraint comes from the app, not from a cluster-wide rule.
+Stateful apps here are conventionally single-replica (the chart default; most
+set no explicit `replicas` or `strategy`). Their `ReadWriteOnce` PVCs bind
+read/write mounting to a single node, which constrains scheduling and rolling
+updates across nodes — but RWO does not prevent multiple pods on that node
+from sharing the volume and is not a single-writer guarantee (Kubernetes has
+`ReadWriteOncePod` for that). resolute's stricter rule is application-level:
+its SQLite database allows one writer, so it pins `replicas: 1` with
+`strategy: Recreate`, routes writes through the one API pod, and must never
+be scaled. That constraint comes from the app, not from RWO or any
+cluster-wide rule.
 
 ## App Pattern
 

--- a/docs/operations/storage-and-backups.md
+++ b/docs/operations/storage-and-backups.md
@@ -79,6 +79,7 @@ This inventory is derived from the currently included resources in
 | `radarr`      | yes           | yes            | yes         | yes        | Separate `radarr-cache` PVC.                                  |
 | `radarr-se`   | yes           | yes            | yes         | yes        | Separate `radarr-se-cache` PVC.                               |
 | `recyclarr`   | yes           | yes            | no          | no         | CronJob workload; default VolSync capacity.                   |
+| `resolute`    | yes           | yes            | no          | no         | Default VolSync capacity; single-writer SQLite API.           |
 | `sabnzbd`     | yes           | yes            | yes         | yes        | NAS availability controls app scale.                          |
 | `seerr`       | yes           | yes            | no          | no         | Separate `seerr-cache` PVC.                                   |
 | `sonarr`      | yes           | yes            | yes         | yes        | Separate `sonarr-cache` PVC.                                  |
@@ -218,17 +219,18 @@ positive signal, but this cluster still needs its own restore evidence.
 
 ## Suggested Pilot
 
-Use Atuin as the first Kopiur pilot. Track the deployment in
-[Deploy atuin](https://github.com/alex-matthews/home-ops/issues/1266).
+Use Atuin as the first Kopiur pilot. Track the adoption in
+[Adopt Kopiur (#1487)](https://github.com/alex-matthews/home-ops/issues/1487).
+The Atuin app rollout and its client/workstation setup are tracked separately
+in [Deploy atuin (#1266)](https://github.com/alex-matthews/home-ops/issues/1266);
+the server-side backup pilot needs the app and its VolSync-protected PVC
+healthy, but does not wait on workstation dotfiles integration.
 
 Atuin is a good pilot because it is useful, small, and lower-risk than the
-media-adjacent workloads. Do not add Kopiur resources for it until the Atuin app
-and VolSync-protected PVC are healthy and the client dotfiles integration is
-understood.
+media-adjacent workloads.
 
-As of 2026-06-25, the latest upstream Kopiur release is `0.4.13`. Re-check the
-chart, CRDs, and examples before the install PR because the project is still
-moving quickly.
+Re-check the current Kopiur chart, CRDs, and examples before the install PR;
+the project is still moving quickly.
 
 The first Atuin PR should stay backup-only:
 


### PR DESCRIPTION
## Summary

One concern: correcting operational documentation and executable agent guidance found in independent review. No manifests changed.

- **Secret mechanisms** ([repo-guide](docs/guides/repo-guide.md)): the guide said two paths; the directly mounted SOPS Secret introduced by #1482 is a third. Now distinguishes: 1Password/ExternalSecret for ordinary credentials (the default), `cluster-secrets` substitution for build-time values, and directly SOPS-encrypted Secrets only for indivisible structured files — explicitly not for ordinary API keys/passwords.
- **Persistence scope** ([add-app skill](.agents/skills/add-app/SKILL.md), repo-guide): "stateful apps use VolSync" was categorical. Now: backup posture follows the app's value and recovery requirements; VolSync is the `default`-namespace protected-state norm; observability storage intentionally uses plain PVCs; never add VolSync just because a PVC exists.
- **RWO semantics** (repo-guide): removed the claim that ReadWriteOnce prevents scaling. Now accurate per upstream Kubernetes semantics: RWO is node-scoped (multiple pods on one node can share it), constrains scheduling/rolling updates, is not a single-writer guarantee (`ReadWriteOncePod` exists for that), and resolute's one-replica/Recreate rule is application-specific.
- **Sensitive-config wording** (add-app skill): "other sensitive values → SOPS" could teach an agent to Git-encrypt ordinary credentials. Tightened to the indivisible-structured-file exception, with credentials always via 1Password/ExternalSecret.
- **Command boundaries** (AGENTS.md): classified `kubectl exec`, `port-forward`, `cp`, and `debug` by behavior — read-only exec/short-lived port-forward are diagnostics; state-changing exec, `cp` into a pod, and `debug` (creates workloads) need approval; copying out of a pod requires a stated reason; none of these paths may touch secret material.
- **Backup inventory** ([storage-and-backups](docs/operations/storage-and-backups.md)): added the missing `resolute` row; the table now matches the actual VolSync component users 1:1 (verified by enumeration). Kopiur pilot tracking repointed from #1266 to #1487, with the Atuin workstation setup explicitly not a gate for the server-side pilot; removed the hardcoded upstream-version sentence in favor of "re-check before the install PR".

## Validation

- `mise exec --no-deps -- oxfmt --check` on all four files — clean.
- Backup table diffed against `grep -l components/volsync kubernetes/apps/*/*/ks.yaml` — exact match.
- Each corrected claim's scope enumerated against current manifests before rewording.