### PR TITLE
feat(snmp-exporter): use SNMPv3 for Synology

### DIFF
--- a/kubernetes/apps/observability/snmp-exporter/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: snmp-exporter
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: snmp-exporter-secret
+    template:
+      data:
+        SNMP_AUTH_PASSWORD: "{{ .SNMP_AUTH_PASSWORD }}"
+        SNMP_PRIV_PASSWORD: "{{ .SNMP_PRIV_PASSWORD }}"
+        SNMP_USERNAME: "{{ .SNMP_USERNAME }}"
+  dataFrom:
+    - extract:
+        key: synology-snmp

--- a/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
@@ -11,6 +11,22 @@ spec:
   interval: 1h
   values:
     fullnameOverride: *app
+    config: |-
+      auths:
+        synology_v3:
+          version: 3
+          security_level: authPriv
+          username: ${SNMP_USERNAME}
+          password: ${SNMP_AUTH_PASSWORD}
+          auth_protocol: SHA
+          priv_protocol: AES
+          priv_password: ${SNMP_PRIV_PASSWORD}
+    extraArgs:
+      - --config.file=/etc/snmp_exporter/snmp.yml
+      - --config.expand-environment-variables
+    envFrom:
+      - secretRef:
+          name: snmp-exporter-secret
     serviceMonitor:
       enabled: true
       params:
@@ -19,7 +35,7 @@ spec:
             - synology
           target: nas.internal
           auth:
-            - public_v2
+            - synology_v3
       scrapeTimeout: 10s
       relabelings:
         - sourceLabels:

--- a/kubernetes/apps/observability/snmp-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./externalsecret.yaml
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml


### PR DESCRIPTION
## Summary

- switch the Synology scrape from SNMPv2c to authenticated and encrypted SNMPv3
- deliver runtime credentials through the existing cluster secret path
- retain the exporter's stock device modules while adding the dedicated SNMPv3 authentication definition

## Validation

- `kubectl kustomize` focused render
- Helm template assertions for config files, environment injection, and ServiceMonitor auth
- server-side dry run for the app resources
- `oxfmt --check` on the three touched YAML files
- `flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets` (206 passed; known offline tunnel-secret warning only)
- checked that credential values are absent from the diff

## Post-merge check

Confirm the external secret and exporter rollout are healthy, then verify the NAS scrape target remains up before disabling SNMPv2c on the device.