### PR TITLE
fix(ai): allow ToolHive host rewriting for Grafana MCP

### DIFF
--- a/kubernetes/apps/ai/mcp/grafana-mcp/app/mcpserver.yaml
+++ b/kubernetes/apps/ai/mcp/grafana-mcp/app/mcpserver.yaml
@@ -14,6 +14,8 @@ spec:
     - streamable-http
     - --address
     - 0.0.0.0:8000
+    - --allowed-hosts
+    - "*"
     - --disable-admin
     - --disable-incident
     - --disable-oncall


### PR DESCRIPTION
## Summary

- allow the Grafana MCP backend to accept Host values rewritten by its trusted ToolHive proxy
- restore compatibility with the DNS-rebinding protection introduced by mcp-grafana 0.17.1
- retain the existing streamable-HTTP transport and read-only tool restrictions

## Why

ToolHive routes initialization through the backend service and pins established sessions to a backend pod. Those requests therefore carry proxy-selected service or pod Host values. mcp-grafana now rejects every non-loopback Host unless explicitly configured, leaving the aggregate MCP server degraded.

The Grafana MCP backend is ClusterIP-only and reachable through the internal ToolHive proxy, matching upstream's documented trusted-proxy case for `--allowed-hosts '*'`. An exact allowlist would be brittle because session pinning uses changing pod addresses.

Refs #1298.

## Validation

- `mise exec -- kubectl kustomize kubernetes/apps/ai/mcp/grafana-mcp/app`
- `mise exec --no-deps -- oxfmt --check kubernetes/apps/ai/mcp/grafana-mcp/app/mcpserver.yaml`
- `mise exec -- flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets` — 206 passed with the known offline tunnel-secret warning
- `git diff --check`

The rendered container image is unchanged. The separate local `flate diff images` helper could not open this checkout because its Git library does not support the repository's `worktreeConfig` extension.