### PR TITLE
feat(cilium): label legacy load balancers

### DIFF
--- a/kubernetes/apps/default/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/default/plex/app/helmrelease.yaml
@@ -71,6 +71,8 @@ spec:
         type: LoadBalancer
         annotations:
           lbipam.cilium.io/ips: 192.168.1.230
+        labels:
+          load-balancer-ip-pool: legacy
         ports:
           http:
             port: *port

--- a/kubernetes/apps/default/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/default/qbittorrent/app/helmrelease.yaml
@@ -73,6 +73,8 @@ spec:
         type: LoadBalancer
         annotations:
           lbipam.cilium.io/ips: 192.168.1.233
+        labels:
+          load-balancer-ip-pool: legacy
         ports:
           bittorrent-tcp:
             port: *torrentPort

--- a/kubernetes/apps/kube-system/cilium/app/networking.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networking.yaml
@@ -74,6 +74,8 @@ metadata:
   name: kube-api
   annotations:
     lbipam.cilium.io/ips: 192.168.1.200
+  labels:
+    load-balancer-ip-pool: legacy
 spec:
   type: LoadBalancer
   selector:

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -23,6 +23,8 @@ spec:
               memory: 2Gi
       envoyService:
         externalTrafficPolicy: Cluster
+        labels:
+          load-balancer-ip-pool: legacy
   shutdown:
     drainTimeout: 180s
   telemetry:


### PR DESCRIPTION
## Summary

- label the five existing Kubernetes LoadBalancer Services for the legacy pool
- propagate the label to both generated Envoy Services through the Service-only EnvoyProxy setting
- establish the first evidence gate for #1427 without changing allocation or advertisement policy

## Validation

- rendered the four affected applications with Kustomize
- inspected the targeted Cilium, Envoy, Plex and qBittorrent renders
- `flate test all`: 206 passed
- server-side dry-run of the EnvoyProxy resource
- `git diff --check`

## Deployment gate

This PR does not change VIPs, IP pools, L2 selection or BGP advertisement. After reconciliation, verify all five labels, unchanged VIPs and unchanged routes. The generated Envoy Services must both receive the label; stop rather than applying an imperative label if propagation fails.

Part of #1427.
