### PR TITLE
docs(agents): add backlink-safe upstream linking instructions

### DIFF
--- a/.agents/instructions/github-linking.instructions.md
+++ b/.agents/instructions/github-linking.instructions.md
@@ -1,0 +1,26 @@
+# GitHub Linking Instructions
+
+Use these rules when writing issues, PRs, comments, or commit messages in this
+repository that reference an issue or PR in another repository.
+
+## Backlink-Safe Upstream References
+
+This repository is public. Referencing an upstream issue with `owner/repo#123`
+shorthand or a plain `https://github.com/...` URL emits a permanent
+cross-reference event into that upstream issue's timeline. Do not create that
+noise.
+
+- Preferred: link through `https://www.github.com/owner/repo/issues/123`. The
+  `www.` prefix defeats GitHub's reference parser but the link stays clickable.
+- Alternative: omit the upstream link entirely and reference the one local
+  issue that carries it.
+- Never use `owner/repo#123` shorthand or bare `github.com` URLs for
+  repositories outside this one.
+
+Local references within this repository (`#123`) are fine and encouraged.
+
+## Cleanup Caveat
+
+Editing a reference out of a body does not reliably remove an already-emitted
+timeline event; only deleting the source issue or comment does. Get the link
+form right before posting.

--- a/docs/guides/repo-guide.md
+++ b/docs/guides/repo-guide.md
@@ -6,8 +6,8 @@ commands. Agent behavior and change-control rules live in
 
 ## Layout
 
-- `.agents/instructions/`: narrow reusable agent instructions, currently YAML
-  ordering.
+- `.agents/instructions/`: narrow reusable agent instructions such as YAML
+  ordering and GitHub linking.
 - `.agents/skills/`: task recipes, currently `add-app`.
 - `.github/actionlint.yaml`: actionlint configuration.
 - `.github/labels.yaml`: label definitions synced by CI.

--- a/docs/guides/repo-guide.md
+++ b/docs/guides/repo-guide.md
@@ -192,6 +192,13 @@ directory when possible:
 mise exec -- kubectl kustomize kubernetes/apps/<namespace>/<app>/app
 ```
 
+## Issue and PR Writing
+
+When referencing an issue or PR in another repository, use backlink-safe link
+forms so this public repository does not emit cross-reference events into
+upstream timelines. See
+[`../../.agents/instructions/github-linking.instructions.md`](../../.agents/instructions/github-linking.instructions.md).
+
 ## Tooling Boundaries
 
 CI runs tools directly. Do not route everything through `just`.


### PR DESCRIPTION
Adds a narrow reusable instruction for referencing upstream issues/PRs without emitting cross-reference events into their timelines (www. link form), following the yaml-ordering instruction pattern, with a pointer from the repo guide.

No manifest or workflow changes.