### PR TITLE
feat(cilium): add service pool selectors

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/networking.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networking.yaml
@@ -7,6 +7,21 @@ spec:
   allowFirstLastIPs: "No"
   blocks:
     - cidr: 192.168.1.0/24
+  serviceSelector:
+    matchLabels:
+      load-balancer-ip-pool: legacy
+---
+apiVersion: cilium.io/v2
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: services
+spec:
+  blocks:
+    - start: 192.168.96.200
+      stop: 192.168.96.254
+  serviceSelector:
+    matchLabels:
+      load-balancer-ip-pool: services
 ---
 apiVersion: cilium.io/v2alpha1
 kind: CiliumL2AnnouncementPolicy
@@ -21,6 +36,9 @@ spec:
   nodeSelector:
     matchLabels:
       kubernetes.io/os: linux
+  serviceSelector:
+    matchLabels:
+      load-balancer-ip-pool: legacy
 ---
 apiVersion: cilium.io/v2
 kind: CiliumBGPAdvertisement


### PR DESCRIPTION
## Summary

- constrain the existing LoadBalancer IP pool to legacy-labelled Services
- add the dedicated Services pool for Services carrying its matching label
- restrict L2 announcements to legacy-labelled Services while leaving BGP advertising unchanged

## Validation

- `kubectl kustomize kubernetes/apps/kube-system/cilium/app`
- `kubectl apply --dry-run=server -f kubernetes/apps/kube-system/cilium/app/networking.yaml`
- `flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets` (206 passed; one existing offline-secret warning)
- `git diff --check`

Related to #1427.
