### PR TITLE
feat(echo): add services network pilot

### DIFF
--- a/kubernetes/apps/network/echo/app/kustomization.yaml
+++ b/kubernetes/apps/network/echo/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./service-pilot.yaml

--- a/kubernetes/apps/network/echo/app/service-pilot.yaml
+++ b/kubernetes/apps/network/echo/app/service-pilot.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-pilot
+  annotations:
+    lbipam.cilium.io/ips: 192.168.96.250
+  labels:
+    load-balancer-ip-pool: services
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Cluster
+  selector:
+    app.kubernetes.io/instance: echo
+    app.kubernetes.io/name: echo
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http


### PR DESCRIPTION
## Summary

- add a temporary echo LoadBalancer for the dedicated Services pool
- retain `externalTrafficPolicy: Cluster` for the classification pilot
- leave the existing echo Service, HTTPRoute, and production LoadBalancers unchanged

## Validation

- verified the live echo workload exposes the named `http` target port
- `kubectl kustomize kubernetes/apps/network/echo/app`
- `kubectl apply --dry-run=server -f kubernetes/apps/network/echo/app/service-pilot.yaml`
- `flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets` (206 passed; one existing offline-secret warning)
- `git diff --check`

Related to #1427.
