### PR TITLE
feat(network): migrate application VIPs to services pool

### DIFF
--- a/kubernetes/apps/default/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/default/plex/app/helmrelease.yaml
@@ -21,7 +21,7 @@ spec:
               tag: 1.43.3.10828@sha256:0c0b6899339503af17cb190b25af6acf10f0030e2820985e16ee14ef428f49d7
             env:
               TZ: Pacific/Auckland
-              PLEX_ADVERTISE_URL: https://plex.${SECRET_DOMAIN}:443,http://192.168.1.230:32400,http://plex.default.svc.cluster.local:32400
+              PLEX_ADVERTISE_URL: https://plex.${SECRET_DOMAIN}:443,http://192.168.96.203:32400,http://plex.default.svc.cluster.local:32400
               PLEX_NO_AUTH_NETWORKS: 192.168.1.0/24
             probes:
               liveness:
@@ -70,9 +70,9 @@ spec:
       app:
         type: LoadBalancer
         annotations:
-          lbipam.cilium.io/ips: 192.168.1.230
+          lbipam.cilium.io/ips: 192.168.96.203
         labels:
-          load-balancer-ip-pool: legacy
+          load-balancer-ip-pool: services
         ports:
           http:
             port: *port

--- a/kubernetes/apps/default/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/default/qbittorrent/app/helmrelease.yaml
@@ -72,9 +72,9 @@ spec:
       bittorrent:
         type: LoadBalancer
         annotations:
-          lbipam.cilium.io/ips: 192.168.1.233
+          lbipam.cilium.io/ips: 192.168.96.204
         labels:
-          load-balancer-ip-pool: legacy
+          load-balancer-ip-pool: services
         ports:
           bittorrent-tcp:
             port: *torrentPort

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -24,7 +24,7 @@ spec:
       envoyService:
         externalTrafficPolicy: Cluster
         labels:
-          load-balancer-ip-pool: legacy
+          load-balancer-ip-pool: services
   shutdown:
     drainTimeout: 180s
   telemetry:
@@ -62,7 +62,7 @@ spec:
   infrastructure:
     annotations:
       external-dns.alpha.kubernetes.io/hostname: *hostname
-      lbipam.cilium.io/ips: 192.168.1.202
+      lbipam.cilium.io/ips: 192.168.96.202
   listeners:
     - name: http
       protocol: HTTP
@@ -99,7 +99,7 @@ spec:
   infrastructure:
     annotations:
       external-dns.alpha.kubernetes.io/hostname: *hostname
-      lbipam.cilium.io/ips: 192.168.1.201
+      lbipam.cilium.io/ips: 192.168.96.201
   listeners:
     - name: http
       protocol: HTTP


### PR DESCRIPTION
Closes the application-VIP phase of #1427.

## Summary

- move both Envoy Gateway Services, Plex, and qBittorrent to the dedicated Services pool
- retain BGP advertisement and `externalTrafficPolicy: Cluster`
- update Plex's direct advertised address with its Service allocation
- leave the Kubernetes API LoadBalancer unchanged

The qBittorrent router forwarding target remains unchanged until the new Service route and application are healthy.

## Validation

- `git diff --check`
- app-level `kubectl kustomize` renders for Envoy Gateway, Plex, and qBittorrent
- `flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets` (206 passed)