### PR TITLE
feat(talos): trust internal API hostname

### DIFF
--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -142,6 +142,7 @@ cluster:
     certSANs:
       - 127.0.0.1
       - 192.168.1.200
+      - k8s.internal
     disablePodSecurityPolicy: true
     extraArgs:
       enable-aggregator-routing: "true"


### PR DESCRIPTION
## Summary

- add the internal Kubernetes API DNS name to the API server certificate SANs
- retain the existing API and machine certificate SANs

## Validation

- rendered and validated all three Talos machine configurations in metal mode
- confirmed the first-node targeted apply was reboot-free and regenerated the API certificate
- confirmed direct-node and legacy API recovery paths remained healthy

Part of #1427.