### PR TITLE
feat(cilium): add parallel API service

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/networking.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networking.yaml
@@ -104,3 +104,23 @@ spec:
       port: 6443
       protocol: TCP
       targetPort: 6443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-api-services
+  annotations:
+    lbipam.cilium.io/ips: 192.168.96.200
+  labels:
+    load-balancer-ip-pool: services
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Cluster
+  selector:
+    k8s-app: kube-apiserver
+    tier: control-plane
+  ports:
+    - name: https
+      port: 6443
+      protocol: TCP
+      targetPort: 6443


### PR DESCRIPTION
## Summary

- add a parallel Kubernetes API LoadBalancer on the Services pool
- keep the legacy API Service unchanged for staged validation and rollback
- retain cluster-wide traffic policy for the migration

## Validation

- app-level Kustomize render
- server-side dry-run in the target namespace
- Flate: 206 passed
- diff check and pre-commit formatting

Part of #1427.