### PR TITLE
feat(talos): use stable API endpoint

### DIFF
--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -109,7 +109,8 @@ cluster:
     {% endif %}
   clusterName: main
   controlPlane:
-    endpoint: https://192.168.1.200:6443
+    # k8s.internal is manually maintained on the router.
+    endpoint: https://k8s.internal:6443
   discovery:
     enabled: true
     registries:


### PR DESCRIPTION
## Summary

- use the stable internal DNS name for the Talos control-plane endpoint
- document that the supporting DNS record is maintained on the router

## Validation

- rendered machine configuration for every control-plane node
- live dry-run on every node showed only the endpoint update and the known hostname representation reconciliation
- every dry-run predicted an in-place apply without reboot
- `git diff --check`

Part of #1427.