### PR TITLE
feat(cilium): remove legacy API service

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/networking.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networking.yaml
@@ -89,25 +89,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: kube-api
-  annotations:
-    lbipam.cilium.io/ips: 192.168.1.200
-  labels:
-    load-balancer-ip-pool: legacy
-spec:
-  type: LoadBalancer
-  selector:
-    k8s-app: kube-apiserver
-    tier: control-plane
-  ports:
-    - name: https
-      port: 6443
-      protocol: TCP
-      targetPort: 6443
----
-apiVersion: v1
-kind: Service
-metadata:
   name: kube-api-services
   annotations:
     lbipam.cilium.io/ips: 192.168.96.200


### PR DESCRIPTION
## Summary

- remove the retired legacy Kubernetes API LoadBalancer Service
- retain the Services-network API Service as the sole load-balanced API path

## Validation

- rendered the Cilium app
- server-side dry-run of the rendered app
- Flate: 206 passing
- formatting and diff checks

Part of #1427.