### PR TITLE
feat(cilium): retire legacy pool and L2 announcements

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -46,7 +46,7 @@ spec:
     kubeProxyReplacement: true
     kubeProxyReplacementHealthzBindAddr: 0.0.0.0:10256
     l2announcements:
-      enabled: true
+      enabled: false
     loadBalancer:
       algorithm: maglev
       mode: dsr

--- a/kubernetes/apps/kube-system/cilium/app/networking.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networking.yaml
@@ -2,18 +2,6 @@
 apiVersion: cilium.io/v2
 kind: CiliumLoadBalancerIPPool
 metadata:
-  name: pool
-spec:
-  allowFirstLastIPs: "No"
-  blocks:
-    - cidr: 192.168.1.0/24
-  serviceSelector:
-    matchLabels:
-      load-balancer-ip-pool: legacy
----
-apiVersion: cilium.io/v2
-kind: CiliumLoadBalancerIPPool
-metadata:
   name: services
 spec:
   blocks:
@@ -22,23 +10,6 @@ spec:
   serviceSelector:
     matchLabels:
       load-balancer-ip-pool: services
----
-apiVersion: cilium.io/v2alpha1
-kind: CiliumL2AnnouncementPolicy
-metadata:
-  name: l2-policy
-spec:
-  loadBalancerIPs: true
-  # NOTE: interfaces might need to be set if you have more than one active NIC on your hosts
-  # interfaces:
-  #   - ^eno[0-9]+
-  #   - ^eth[0-9]+
-  nodeSelector:
-    matchLabels:
-      kubernetes.io/os: linux
-  serviceSelector:
-    matchLabels:
-      load-balancer-ip-pool: legacy
 ---
 apiVersion: cilium.io/v2
 kind: CiliumBGPAdvertisement


### PR DESCRIPTION
Stage 6 of #1427: removes the legacy IP pool and L2 announcement policy, and disables Cilium L2 announcements. All production LoadBalancers are BGP-only on the Services pool. The Helm value change rolls the Cilium DaemonSet.