### PR TITLE
feat(cilium): simplify to selector-less pool and stable kube-api name

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/networking.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networking.yaml
@@ -7,9 +7,6 @@ spec:
   blocks:
     - start: 192.168.96.200
       stop: 192.168.96.254
-  serviceSelector:
-    matchLabels:
-      load-balancer-ip-pool: services
 ---
 apiVersion: cilium.io/v2
 kind: CiliumBGPAdvertisement
@@ -60,11 +57,9 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: kube-api-services
+  name: kube-api
   annotations:
     lbipam.cilium.io/ips: 192.168.96.200
-  labels:
-    load-balancer-ip-pool: services
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Cluster


### PR DESCRIPTION
Follow-up to #1427, converging on the peer pattern now that a single pool remains:

- Remove the Services pool's serviceSelector (selector-less single pool).
- Rename kube-api-services to kube-api and drop its pool label.

Expected: a brief kube-api VIP handover blip while the renamed Service takes over the pinned address. DNS name and address are unchanged. App-side label removal follows separately once this reconciles, to avoid cross-Kustomization ordering races.