### PR TITLE
chore: drop inert pool labels and note rebuild kubeconfig timing

### DIFF
--- a/bootstrap/mod.just
+++ b/bootstrap/mod.just
@@ -33,6 +33,8 @@ k8s:
         sleep 5
     done
 
+# The final kubeconfig targets the stable DNS endpoint, whose LoadBalancer VIP
+# only exists after Flux reconciles the Cilium networking app on a rebuild.
 [private]
 kubeconfig lb="cilium":
     just log info "Running stage..." "stage" "{{ recipe_name() }}"

--- a/kubernetes/apps/default/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/default/plex/app/helmrelease.yaml
@@ -71,8 +71,6 @@ spec:
         type: LoadBalancer
         annotations:
           lbipam.cilium.io/ips: 192.168.96.203
-        labels:
-          load-balancer-ip-pool: services
         ports:
           http:
             port: *port

--- a/kubernetes/apps/default/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/default/qbittorrent/app/helmrelease.yaml
@@ -73,8 +73,6 @@ spec:
         type: LoadBalancer
         annotations:
           lbipam.cilium.io/ips: 192.168.96.204
-        labels:
-          load-balancer-ip-pool: services
         ports:
           bittorrent-tcp:
             port: *torrentPort

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -23,8 +23,6 @@ spec:
               memory: 2Gi
       envoyService:
         externalTrafficPolicy: Cluster
-        labels:
-          load-balancer-ip-pool: services
   shutdown:
     drainTimeout: 180s
   telemetry:


### PR DESCRIPTION
Final #1427 cleanup after the pool went selector-less in #1549: removes the now-inert load-balancer-ip-pool labels from the Envoy, Plex and qBittorrent Services (allocation-neutral; the single pool matches all LoadBalancers), and documents the rebuild-time kubeconfig/VIP timing in the bootstrap helper.