### PR TITLE
feat(echo): eTP Local experiment (#1536)

### DIFF
--- a/kubernetes/apps/network/echo/app/kustomization.yaml
+++ b/kubernetes/apps/network/echo/app/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./service-local.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/network/echo/app/service-local.yaml
+++ b/kubernetes/apps/network/echo/app/service-local.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-local
+  annotations:
+    lbipam.cilium.io/ips: 192.168.96.250
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  selector:
+    app.kubernetes.io/instance: echo
+    app.kubernetes.io/name: echo
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http


### PR DESCRIPTION
Disposable echo LoadBalancer with externalTrafficPolicy: Local at the pilot address, to verify per-node BGP advertisement follows local endpoints on Cilium 1.19.6 (post-fix for the upstream regression). Will be torn down after observation; tracked in #1536.