### PR TITLE
feat(talos): drop obsolete API certificate SANs (#1530)

### DIFF
--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -6,9 +6,6 @@ machine:
     {% if ENV.CONTROLPLANE %}
     key: op://kubernetes/talos/MACHINE_CA_KEY
     {% endif %}
-  certSANs:
-    - 127.0.0.1
-    - 192.168.1.200
   features:
     apidCheckExtKeyUsage: true
     diskQuotaSupport: true
@@ -140,9 +137,9 @@ cluster:
       kind: Policy
       rules:
         - level: Metadata
+    # Only the stable DNS identity is configured; Talos adds node/localhost
+    # SANs by default. Direct VIP-by-IP TLS is intentionally unsupported.
     certSANs:
-      - 127.0.0.1
-      - 192.168.1.200
       - k8s.internal
     disablePodSecurityPolicy: true
     extraArgs:


### PR DESCRIPTION
Removes the legacy VIP and loopback entries from cluster.apiServer.certSANs (Talos includes localhost and node addresses as default SANs — verified against peer clusters running this exact shape) and removes the machine.certSANs block, whose entries were vestigial since talosconfig endpoints target the nodes directly. Applies will be per-node with certificate verification between nodes; first node verifies the localhost default-SAN assumption before the rest proceed.