### PR TITLE
feat(talos): adopt graceful shutdown, mtu probing and hardware watchdog (#1530)

### DIFF
--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -57,6 +57,8 @@ machine:
     disableManifestsDirectory: true
     extraConfig:
       serializeImagePulls: false
+      shutdownGracePeriod: 90s
+      shutdownGracePeriodCriticalPods: 60s
     extraMounts:
       - destination: /var/openebs/local
         type: bind
@@ -88,6 +90,7 @@ machine:
     net.ipv4.neigh.default.gc_thresh2: "8192"
     net.ipv4.neigh.default.gc_thresh3: "16384"
     net.ipv4.ping_group_range: 0 2147483647
+    net.ipv4.tcp_mtu_probing: "1"
     net.ipv4.tcp_congestion_control: bbr
     net.ipv4.tcp_fastopen: "3"
     net.ipv4.tcp_notsent_lowat: "131072"
@@ -206,8 +209,8 @@ cluster:
 #     match: system_disk
 #   minSize: 200GiB
 #   grow: true
-# ---
-# apiVersion: v1alpha1
-# kind: WatchdogTimerConfig
-# device: /dev/watchdog0
-# timeout: 5m
+---
+apiVersion: v1alpha1
+kind: WatchdogTimerConfig
+device: /dev/watchdog0
+timeout: 5m

--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -192,23 +192,6 @@ cluster:
   serviceAccount:
     key: op://kubernetes/talos/CLUSTER_SERVICEACCOUNT_KEY
   {% endif %}
-# ---
-# apiVersion: v1alpha1
-# kind: VolumeConfig
-# name: EPHEMERAL
-# provisioning:
-#   diskSelector:
-#     match: system_disk
-#   maxSize: 200GiB
-# ---
-# apiVersion: v1alpha1
-# kind: UserVolumeConfig
-# name: local-hostpath
-# provisioning:
-#   diskSelector:
-#     match: system_disk
-#   minSize: 200GiB
-#   grow: true
 ---
 apiVersion: v1alpha1
 kind: WatchdogTimerConfig


### PR DESCRIPTION
Peer-comparison adoptions from the #1530 review, each verified locally applicable:

- Kubelet graceful node shutdown (90s/60s critical), matching onedr0p.
- net.ipv4.tcp_mtu_probing=1, present in both reference repos.
- WatchdogTimerConfig on /dev/watchdog0 (device verified present on the nodes), matching buroa; this was already drafted as a comment in our template.

Deliberately not adopted, with reasons recorded in the issue: NFS 4.2/transfer-size/sunrpc tuning (NAS-capability and 10Gb-specific), multi-document network configs (deferred to the Servers-network rebuild), secret-reference prefix differences (different templating toolchain).