### PR TITLE
feat(talos): enable watchdog timer, drop volume config placeholders

### DIFF
--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -189,25 +189,8 @@ cluster:
   serviceAccount:
     key: op://kubernetes/talos/CLUSTER_SERVICEACCOUNT_KEY
   {% endif %}
-# ---
-# apiVersion: v1alpha1
-# kind: VolumeConfig
-# name: EPHEMERAL
-# provisioning:
-#   diskSelector:
-#     match: system_disk
-#   maxSize: 200GiB
-# ---
-# apiVersion: v1alpha1
-# kind: UserVolumeConfig
-# name: local-hostpath
-# provisioning:
-#   diskSelector:
-#     match: system_disk
-#   minSize: 200GiB
-#   grow: true
-# ---
-# apiVersion: v1alpha1
-# kind: WatchdogTimerConfig
-# device: /dev/watchdog0
-# timeout: 5m
+---
+apiVersion: v1alpha1
+kind: WatchdogTimerConfig
+device: /dev/watchdog0
+timeout: 5m


### PR DESCRIPTION
## What

- Activates the `WatchdogTimerConfig` document (`/dev/watchdog0`, 5m timeout) for all nodes.
- Removes the commented-out `VolumeConfig`/`UserVolumeConfig` placeholder blocks.

Increments 2 and 3 of the #1530 findings review.

## Why

- Watchdog: peer-proven hung-node recovery; precondition verified read-only on 2026-07-18 — `/dev/watchdog0` present on all three nodes.
- Volume placeholders: the peer equivalent of these blocks is a miroir `RawVolumeConfig`, so the volume decision is coupled to the #1488 storage evaluation and should be made there, not carried as dead comments here.

## Validation

- Template renders cleanly in both roles (minijinja with `CONTROLPLANE` set and empty); document set is machine config + `WatchdogTimerConfig` only.
- Merging changes no live state: machine config is applied per node via `just talos apply-node`, which stays a separately approved step.

## Rollback

- Pre-apply: revert this commit.
- Post-apply: re-apply the previous rendered config per node (`apply-node`); the watchdog document is removable without reboot.