### PR TITLE
feat(kopiur): add operator and backup-only bazarr pilot

### DIFF
--- a/kubernetes/apps/default/bazarr/backup/externalsecret.yaml
+++ b/kubernetes/apps/default/bazarr/backup/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kopiur-pilot
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: kopiur-pilot-secret
+    template:
+      data:
+        KOPIA_PASSWORD: "{{ .KOPIA_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: kopiur

--- a/kubernetes/apps/default/bazarr/backup/kopiur.yaml
+++ b/kubernetes/apps/default/bazarr/backup/kopiur.yaml
@@ -1,0 +1,56 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/repository_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Repository
+metadata:
+  name: kopiur-pilot
+spec:
+  # Dedicated Synology NFS export for the pilot only (#1487). This does not
+  # select inline NFS as the production backend; see
+  # docs/operations/storage-and-backups.md.
+  backend:
+    filesystem:
+      path: /repo
+      volume:
+        nfs:
+          server: nas.internal
+          path: /volume1/kopiur-pilot
+  encryption:
+    passwordSecretRef:
+      name: kopiur-pilot-secret
+      key: KOPIA_PASSWORD
+  create:
+    enabled: true
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: bazarr
+spec:
+  repository:
+    name: kopiur-pilot
+  sources:
+    - pvc:
+        name: bazarr
+  retention:
+    keepDaily: 7
+    keepWeekly: 4
+  mover:
+    # Match bazarr's defaultPodOptions so the mover can read the app's files.
+    securityContext:
+      runAsUser: 1032
+      runAsGroup: 100
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotschedule_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: bazarr
+spec:
+  policyRef:
+    name: bazarr
+  schedule:
+    cron: "H 2 * * *"
+    jitter: 30m
+    runOnCreate: false

--- a/kubernetes/apps/default/bazarr/backup/kustomization.yaml
+++ b/kubernetes/apps/default/bazarr/backup/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./kopiur.yaml

--- a/kubernetes/apps/default/bazarr/ks.yaml
+++ b/kubernetes/apps/default/bazarr/ks.yaml
@@ -26,3 +26,22 @@ spec:
     namespace: flux-system
   targetNamespace: default
   wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: bazarr-backup
+spec:
+  dependsOn:
+    - name: kopiur
+      namespace: kopiur-system
+  interval: 1h
+  path: ./kubernetes/apps/default/bazarr/backup
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: default
+  wait: false

--- a/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kopiur
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: kopiur
+  interval: 1h
+  values:
+    # Pilot install (#1487): defaults only, least privilege. installScope stays
+    # "cluster" (chart default) so CRs in workload namespaces reconcile, but the
+    # secrets-write feature flags (credentialProjection, kopiaUi) remain off —
+    # the pilot uses a namespaced Repository, so no projection is needed.
+    monitoring:
+      serviceMonitor:
+        enabled: true
+      prometheusRule:
+        enabled: true

--- a/kubernetes/apps/kopiur-system/kopiur/app/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/kopiur-system/kopiur/app/ocirepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kopiur
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.7.5
+  url: oci://ghcr.io/home-operations/charts/kopiur

--- a/kubernetes/apps/kopiur-system/kopiur/ks.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/ks.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kopiur
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/kopiur-system/kopiur/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: kopiur-system
+  wait: true

--- a/kubernetes/apps/kopiur-system/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kopiur-system
+components:
+  - ../../components/alerts
+resources:
+  - ./namespace.yaml
+  - ./kopiur/ks.yaml

--- a/kubernetes/apps/kopiur-system/namespace.yaml
+++ b/kubernetes/apps/kopiur-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
## What

Backup-only Kopiur pilot per the plan in `docs/operations/storage-and-backups.md` and the 0.7.5 release-gate review on #1487:

- `kopiur-system` namespace + operator from the signed OCI chart (`oci://ghcr.io/home-operations/charts/kopiur` 0.7.5, image digests pinned at chart publish). ServiceMonitor + PrometheusRule enabled; both secrets-write feature flags left off (operator secrets access stays read-only).
- Bazarr pilot resources in a separate Flux Kustomization (`bazarr-backup`, `dependsOn: kopiur`) so the existing bazarr app Kustomization is untouched: namespaced `Repository` on a dedicated inline-NFS export (`nas.internal:/volume1/kopiur-pilot`), `SnapshotPolicy` with the mover matched to bazarr's `1032:100`, nightly `SnapshotSchedule` (`H 2 * * *`, 30m jitter, no run-on-create).
- `KOPIA_PASSWORD` via ExternalSecret from the `kopiur` 1Password item.

VolSync Restic remains the production backup system. No change to the bazarr PVC, `dataSourceRef`, storage class, UID/GID, or restore wiring.

## Prerequisites before merge (operator-side)

1. 1Password: create item `kopiur` (same vault onepassword-connect serves) with field `KOPIA_PASSWORD` = long random value.
2. Synology: create the `kopiur-pilot` shared folder + NFS rule and chown it `1032:100` (instructions in the session notes / #1487).

## Validation

- `kubectl kustomize` clean on all three new/changed paths; `oxfmt --check` clean.
- `flate test all` (full cluster render): 210 passed.
- Post-merge sequence: operator Ready → `Repository` goes `Initializing` → `Ready` (bootstrap mover Job mounts the export; a permissions failure emits a Warning Event naming the actual UID) → first manual `Snapshot`, then a second after an app-generated change → `Restore` into a temporary PVC. Gates recorded in #1487.

## Rollback

Revert the PR: Flux prunes the operator and pilot CRs. The kopia repository on the NAS is inert data — delete `/volume1/kopiur-pilot` to reclaim it. Nothing in the VolSync path depends on any of this.