### PR TITLE
fix(kopiur): run repository movers as the export owner UID

### DIFF
--- a/kubernetes/apps/default/bazarr/backup/kopiur.yaml
+++ b/kubernetes/apps/default/bazarr/backup/kopiur.yaml
@@ -21,6 +21,12 @@ spec:
       key: KOPIA_PASSWORD
   create:
     enabled: true
+  moverDefaults:
+    # Bootstrap and maintenance movers run against the NFS export, which is
+    # owned 1032:100 with mode 770 — the mover default UID (65532) is denied.
+    securityContext:
+      runAsUser: 1032
+      runAsGroup: 100
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
 apiVersion: kopiur.home-operations.com/v1alpha1


### PR DESCRIPTION
Bootstrap failed with kopia PermissionDenied on the NFS export: repository-level movers (bootstrap, maintenance) default to UID 65532 and take their securityContext from `Repository.spec.moverDefaults`, which #1557 left unset — only the `SnapshotPolicy` backup movers were matched to the export owner (1032:100). Sets `moverDefaults.securityContext` accordingly (field verified against the 0.7.5 CRD).

Validation: `kubectl kustomize` + `oxfmt` clean. Post-merge: spec change retriggers bootstrap; expected `Repository` phase `Initializing → Ready`. Rollback: revert; no state involved (the failed bootstrap wrote nothing to the export).