### PR TITLE
fix(kopiur): retain snapshots on CR deletion during the pilot

### DIFF
--- a/docs/operations/storage-and-backups.md
+++ b/docs/operations/storage-and-backups.md
@@ -351,6 +351,14 @@ and file upstream if still present when it next bites:
   take their identity from `Repository.spec.moverDefaults.securityContext`,
   not from any `SnapshotPolicy` — leave it unset and they run as UID 65532,
   which a UID-owned NFS export will refuse.
+- Deleting a `SnapshotPolicy`/`SnapshotSchedule` (including via Flux prune)
+  under the default `deletionPolicy: Delete` cascades into one delete Job per
+  retained snapshot and purges the repository (community report: 600–700 pods
+  from one accidental deletion). Upstream mass-deletion protection merged in
+  home-operations/kopiur#265 the day after 0.7.5 tagged; until a release
+  contains it, the pilot policy sets `defaultDeletionPolicy: Retain` and
+  accepts that repo-side GFS pruning is disabled (CRs prune; kopia snapshots
+  accumulate). Flip back to `Delete` when upgrading past #265.
 
 ## Validation Commands
 

--- a/kubernetes/apps/default/bazarr/backup/kopiur.yaml
+++ b/kubernetes/apps/default/bazarr/backup/kopiur.yaml
@@ -36,6 +36,12 @@ metadata:
 spec:
   repository:
     name: kopiur-pilot
+  # Pilot-term guard: 0.7.5 predates upstream's mass-deletion protection
+  # (home-operations/kopiur#265), so CR deletion — including a Flux prune —
+  # would cascade-delete repo snapshots. Retain breaks repo-side GFS pruning
+  # (CRs are pruned, kopia snapshots accumulate), acceptable at pilot scale.
+  # Revisit on the first release containing #265.
+  defaultDeletionPolicy: Retain
   sources:
     - pvc:
         name: bazarr


### PR DESCRIPTION
0.7.5 has no cascade guard — deleting the `SnapshotPolicy`/`SnapshotSchedule` (a Flux prune counts) under the default `deletionPolicy: Delete` mass-deletes repo snapshots via one Job each (community incident: 600–700 pods). Upstream fix home-operations/kopiur#265 merged the day after 0.7.5 was tagged and is unreleased.

Sets `defaultDeletionPolicy: Retain` on the pilot policy as an explicitly pilot-term guard: retention still prunes CRs but kopia snapshots accumulate; irrelevant at Bazarr scale, revisit at the first release containing #265 (tracked in the storage doc quirks section, updated here too).

Validation: kustomize + oxfmt clean. Note: existing `Snapshot` CRs keep their stamped policy — the already-taken manual snapshot needs a one-off patch, proposed separately.