### PR TITLE
feat(kopiur): compute pilot schedules in local time

### DIFF
--- a/kubernetes/apps/default/bazarr/backup/kopiur.yaml
+++ b/kubernetes/apps/default/bazarr/backup/kopiur.yaml
@@ -21,6 +21,11 @@ spec:
       key: KOPIA_PASSWORD
   create:
     enabled: true
+  # Inherited by every schedule consumer (backup cron, maintenance,
+  # verification); without it crons compute in UTC, putting the "02:00 backup"
+  # and daily full maintenance in the mid-afternoon busy window.
+  scheduleDefaults:
+    timezone: Pacific/Auckland
   moverDefaults:
     # Bootstrap and maintenance movers run against the NFS export, which is
     # owned 1032:100 with mode 770 — the mover default UID (65532) is denied.


### PR DESCRIPTION
Evidence from the pilot's first scheduled cycle: the schedule computed `H 2 * * *` in UTC (status showed `nextSchedule.timezone: UTC`), so the nightly backup fired mid-afternoon local, and managed maintenance's daily full pass has the same skew — exactly the NAS-busy window the storage plan says to avoid. That first scheduled snapshot succeeded (Retain auto-stamped, non-zero file reads), so the scheduled path itself is proven.

Fix is one inherited field: `Repository.spec.scheduleDefaults.timezone: Pacific/Auckland` — consumed by the SnapshotSchedule cron, managed Maintenance, and verification schedules (upstream example 29; field present in the 0.7.5 CRD). A referent watch recomputes the pinned slot on merge; expected observable: the schedule's `status.nextSchedule` moves from 03:15 UTC to a `0200–0230 Pacific/Auckland` slot.

Validation: kustomize + oxfmt clean. Rollback: revert; schedules return to UTC interpretation with no data impact.