### PR TITLE
fix(kopiur): retire pilot Retain guard on 0.8.0

### DIFF
--- a/docs/operations/storage-and-backups.md
+++ b/docs/operations/storage-and-backups.md
@@ -352,13 +352,16 @@ and file upstream if still present when it next bites:
   not from any `SnapshotPolicy` — leave it unset and they run as UID 65532,
   which a UID-owned NFS export will refuse.
 - Deleting a `SnapshotPolicy`/`SnapshotSchedule` (including via Flux prune)
-  under the default `deletionPolicy: Delete` cascades into one delete Job per
-  retained snapshot and purges the repository (community report: 600–700 pods
-  from one accidental deletion). Upstream mass-deletion protection merged in
-  home-operations/kopiur#265 the day after 0.7.5 tagged; until a release
-  contains it, the pilot policy sets `defaultDeletionPolicy: Retain` and
-  accepts that repo-side GFS pruning is disabled (CRs prune; kopia snapshots
-  accumulate). Flip back to `Delete` when upgrading past #265.
+  no longer purges the repository as of kopiur 0.8.0: policy/schedule deletion
+  cascades only to the `Snapshot` CRs (`spec.deletion.onPolicyDelete` /
+  `onScheduleDelete`, default `Retain` — kopia data preserved), and repo-side
+  deletions route through the mass-deletion circuit breaker
+  (`Repository.spec.deletionProtection.threshold`, default 10). The pilot's
+  interim `defaultDeletionPolicy: Retain` guard from the 0.7.5 era is retired;
+  produced snapshots default to `Delete`, so GFS retention prunes repo-side
+  again. Kopia snapshots orphaned during the Retain era are re-adopted as
+  managed CRs (`origin: adopted`) via the 0.8.0 catalog scan and then age out
+  under normal retention.
 
 ## Validation Commands
 

--- a/kubernetes/apps/default/bazarr/backup/kopiur.yaml
+++ b/kubernetes/apps/default/bazarr/backup/kopiur.yaml
@@ -41,12 +41,6 @@ metadata:
 spec:
   repository:
     name: kopiur-pilot
-  # Pilot-term guard: 0.7.5 predates upstream's mass-deletion protection
-  # (home-operations/kopiur#265), so CR deletion — including a Flux prune —
-  # would cascade-delete repo snapshots. Retain breaks repo-side GFS pruning
-  # (CRs are pruned, kopia snapshots accumulate), acceptable at pilot scale.
-  # Revisit on the first release containing #265.
-  defaultDeletionPolicy: Retain
   sources:
     - pvc:
         name: bazarr


### PR DESCRIPTION
Retires the pilot-era `defaultDeletionPolicy: Retain` guard on the bazarr `SnapshotPolicy` and refreshes the storage doc's quirks entry.

**Why now**: kopiur 0.8.0 (merged in #1568) ships the upstream mass-deletion protection the guard was standing in for — policy/schedule deletion cascades only to `Snapshot` CRs (`deletion.onPolicyDelete`/`onScheduleDelete` default `Retain`, kopia data preserved) and repo-side deletions route through the per-repository circuit breaker (`deletionProtection.threshold`, default 10). Removing the field restores the produced-snapshot default of `Delete`, so GFS retention prunes repo-side again.

**Merge gate**: after the next scheduled snapshot completes cleanly on the 0.8.0 operator (tonight ~02:00–03:30).

**Post-merge follow-ups** (separately, on the live cluster):
- Re-stamp the two existing `Snapshot` CRs (`bazarr-manual-5t6gn`, latest scheduled) from `deletionPolicy: Retain` to `Delete` so retention can govern them.
- Watch the catalog scan re-adopt the kopia snapshot orphaned during the Retain era (`origin: adopted`) and confirm it ages out under retention.
- Confirm repo-side pruning resumes on the following maintenance run.