### PR TITLE
docs(adr): decide kopiur backend and remote shape

### DIFF
--- a/docs/adr/0002-kopiur-backup-storage-shape.md
+++ b/docs/adr/0002-kopiur-backup-storage-shape.md
@@ -1,0 +1,80 @@
+# ADR-0002: Kopiur Local Backend and Remote Shape
+
+- **Status:** Accepted
+- **Date:** 2026-07-20
+- **Related:** [Issue #1487](https://github.com/alex-matthews/home-ops/issues/1487)
+
+## Context and Problem Statement
+
+The Kopiur pilot (bazarr, NFS export on the NAS) proved the snapshot,
+maintenance, and restore mechanism end-to-end. Two storage decisions remained
+open: the production local backend (inline NFS versus an S3 service), and the
+off-site shape (`RepositoryReplication` to R2 versus an independent R2
+repository).
+
+A 20 GiB synthetic-load test (2026-07-20) supplied the missing evidence:
+
+- Backup wrote at ~165 MB/s and never disturbed anything.
+- Restore read at ~63 MB/s and made the NAS **NFS service** stop answering new
+  TCP connections; the `nfs_probe` health check failed and the zeroscaler HPAs
+  scaled every NAS-dependent app (including Plex) to zero mid-restore,
+  recovering 30 seconds later.
+- Incremental snapshots and compression behaved as expected (5 s mover for a
+  68 MB change; compressible data collapsed in the repository).
+
+The casualty was the NFS daemon's connection handling under Kopiur's read
+load — not disk bandwidth. Community experience adds that
+`RepositoryReplication` cannot filter snapshots, so a replicated remote
+inherits the local cadence and retention wholesale.
+
+## Decision Drivers
+
+- The `nfs_probe` → zeroscaler guardrail is deliberate hang-mount protection
+  and stays as-is; backups must not trip it.
+- The NAS has a single storage volume; no separate pool or disks exist.
+- Remote cadence and retention should be settable independently of local.
+- Off-site copies should not share a corruption domain with the local
+  repository.
+- Low operational burden; prefer shapes proven in peer repositories.
+
+## Considered Options
+
+1. **Local: inline NFS** (pilot shape) — rejected. Kopiur traffic shares the
+   NFS daemon with every runtime app mount; restore-scale reads knock the
+   daemon over and the guardrail takes all NAS apps down.
+2. **Local: S3 on cluster storage** — rejected. Backups would share the
+   Rook-Ceph failure domain with the data they protect.
+3. **Local: S3 served by Garage on the NAS** — chosen. Moves backup IO onto a
+   separate daemon so the NFS service no longer carries it; spindle contention
+   remains but was harmless in both test directions. No new volume is needed —
+   the isolation that matters is service-level, not disk-level. A peer
+   repository runs Kopiur against an S3 endpoint on its NAS host the same way
+   ([ClusterRepository](https://www.github.com/onedr0p/home-ops/blob/main/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml)).
+4. **Remote: `RepositoryReplication` to R2** — rejected. Couples remote
+   cadence/retention to local, propagates local repository damage, and its
+   seed/sync reads the local repository — on NFS, the exact read pattern that
+   tripped the guardrail.
+5. **Remote: independent R2 repository** — chosen. Own cadence, retention,
+   password, and maintenance; reads the CSI-staged clone (never the NAS); an
+   independent corruption domain. Costs a second snapshot job and maintenance
+   lifecycle per app, which is nvme-side and acceptable.
+
+## Decision
+
+- The production local backend is **S3 served by Garage running on the NAS**,
+  with data in a shared folder on the existing volume.
+- The off-site shape is an **independent R2 repository** with its own schedule
+  and retention. `RepositoryReplication` is not used.
+
+## Consequences
+
+- The zeroscaler trip mechanism observed in the pilot is defused for both the
+  local path (different daemon) and the R2 path (NAS not involved).
+- Garage is a NAS-side service outside GitOps: its setup and upgrade path must
+  be documented in the NAS runbook, and it becomes a dependency of the backup
+  (not restore-from-R2) path.
+- The pilot's `RepositoryReplication` gates in the storage document are
+  superseded; the restore-from-R2 proof moves to the first production app's
+  acceptance criteria.
+- The pilot repository migrates to the S3 backend during production rollout;
+  the NFS pilot export is retired afterwards.

--- a/docs/operations/storage-and-backups.md
+++ b/docs/operations/storage-and-backups.md
@@ -260,8 +260,11 @@ Inline NFS is intentionally provisional. [Kopia warns](https://kopia.io/docs/adv
 that network filesystems may not provide the required crash and partition
 consistency, while introducing Garage would add a separate service and metadata
 lifecycle to the first test.
-After the local proof, compare inline NFS with Garage S3 using the measured
-maintenance and restore evidence before selecting the wider local-backup shape.
+The local-backend comparison is decided:
+[ADR-0002](../adr/0002-kopiur-backup-storage-shape.md) selects S3 served by
+Garage on the NAS over inline NFS, based on the pilot and synthetic-load
+evidence (restore-scale NFS reads made the NFS daemon unresponsive and
+triggered the zeroscaler guardrail).
 
 ### Remote R2 Posture
 
@@ -278,31 +281,14 @@ Kopiur supports two valid off-site shapes:
   cost of a second backup pipeline, duplicate source work, and another
   maintenance lifecycle.
 
-The recommended initial remote posture, after the local snapshot, maintenance,
-and restore gates pass, is `RepositoryReplication` to R2 with
-`deleteExtra: false`. This is the safer initial deletion posture:
-destination-only blobs are retained rather than pruned when they disappear from
-the source. Tune parallelism only after measuring the initial seed, and prove
-the destination by attaching it as a recovery repository and restoring into a
-temporary PVC. A successful replication status alone is not restore evidence.
-See the
-[Kopiur replication](https://github.com/home-operations/kopiur/blob/main/docs/replication.md)
-and [Kopia synchronization](https://kopia.io/docs/advanced/synchronization/)
-semantics.
-
-After repeated snapshots, maintenance runs, replications, and direct R2 restores,
-choose the long-term posture:
-
-- Keep additive replication when its growth and restore performance are
-  acceptable. This remains the default recommendation.
-- Consider `deleteExtra: true` only if an exact, compact mirror is worth allowing
-  source-side deletions to prune R2 on the next sync.
-- Use an independent R2 repository instead when isolation from local repository
-  corruption or maintenance errors is more important than the extra jobs,
-  PVC reads, repository state, and maintenance.
-
-This remote choice is separate from the later inline-NFS-versus-Garage decision
-for the local repository.
+The remote shape is decided:
+[ADR-0002](../adr/0002-kopiur-backup-storage-shape.md) selects an independent
+R2 repository with its own schedule and retention; `RepositoryReplication` is
+not used (it cannot filter snapshots, shares the local corruption domain, and
+its sync reads the local repository). The restore-from-R2 proof — attaching
+the R2 repository and restoring into a temporary PVC — is part of the first
+production app's acceptance criteria. A successful backup status alone is not
+restore evidence.
 
 Bazarr is large enough to validate a real application restore but too small to
 stress the spinning-disk NAS. If backend performance is still uncertain, use a
@@ -319,10 +305,9 @@ Pilot success means:
   and no unacceptable interference with media workloads.
 - A restore into a temporary PVC preserves expected ownership and files, and
   the restored Bazarr database passes an integrity check.
-- `RepositoryReplication` completes to R2 with `deleteExtra: false`, reports
-  useful status, and has measured initial-seed and incremental runtimes.
-- The R2 destination is attached as a recovery repository and completes a
-  temporary-PVC restore; replication status alone does not satisfy this gate.
+- The R2 gates originally defined here (replication seed and recovery restore)
+  are superseded by [ADR-0002](../adr/0002-kopiur-backup-storage-shape.md);
+  the restore-from-R2 proof moves to the first production app's acceptance.
 - If used, the synthetic test records snapshot and maintenance duration, data
   shape, repository growth, and NAS impact separately from the app test.
 - Rollback is simply deleting the pilot Kopia resources.


### PR DESCRIPTION
ADR-0002: the production Kopiur local backend is S3 served by Garage on the NAS (service-level isolation from the NFS daemon; no new volume needed), and the off-site shape is an independent R2 repository with its own cadence — `RepositoryReplication` rejected.

Written in the concise decision-record shape rather than ADR-0001's long-form architecture style.

Evidence base: the 2026-07-20 synthetic-load test — restore-scale NFS reads made the NFS daemon unresponsive, tripping the `nfs_probe` → zeroscaler guardrail and scaling all NAS-dependent apps to zero mid-restore; backup direction never tripped it. Replication additionally couples remote cadence to local and reads the local repository for sync.

Also amends the storage doc: local-backend comparison marked decided, the `RepositoryReplication` posture section replaced with the decision pointer, and the pilot's replication gates superseded (restore-from-R2 proof moves to first production app acceptance).