### PR TITLE
docs: index the newer operations docs and ADR-0002

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,6 @@ diagnostics, Talos operations, and VolSync restore helpers.
   cluster-health triage loop.
 - [Storage and Backups](docs/operations/storage-and-backups.md) describes the
   current backup posture and backup migration criteria.
-- [Appliance TLS](docs/operations/appliance-tls.md) covers certificate renewal
-  and replacement for the LAN-only management UIs.
-- [Talos Access and Break-Glass](docs/operations/talos-access-and-break-glass.md)
-  records supported API identities and recovery access paths.
 
 ## Thanks
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ applied by Flux.
   [1Password Connect](https://1password.com/)
 - Storage: [Rook-Ceph](https://github.com/rook/rook),
   [OpenEBS](https://github.com/openebs/openebs), and Synology NFS
-- Backups: [VolSync](https://github.com/backube/volsync)
+- Backups: [VolSync](https://github.com/backube/volsync), with
+  [Kopiur](https://github.com/home-operations/kopiur) adoption in progress
 - Observability:
   [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts),
   [Grafana](https://github.com/grafana/grafana), and
@@ -136,6 +137,10 @@ diagnostics, Talos operations, and VolSync restore helpers.
   cluster-health triage loop.
 - [Storage and Backups](docs/operations/storage-and-backups.md) describes the
   current backup posture and backup migration criteria.
+- [Appliance TLS](docs/operations/appliance-tls.md) covers certificate renewal
+  and replacement for the LAN-only management UIs.
+- [Talos Access and Break-Glass](docs/operations/talos-access-and-break-glass.md)
+  records supported API identities and recovery access paths.
 
 ## Thanks
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,12 +6,15 @@ experiments out of this tree.
 
 ## Map
 
-| Need                                          | Read or update                                                       |
-| --------------------------------------------- | -------------------------------------------------------------------- |
-| Understand repo layout, validation, and peers | [Repo Guide](guides/repo-guide.md)                                   |
-| Understand the AI workbench architecture      | [ADR-0001: AI Home-Ops Workbench](adr/0001-ai-home-ops-workbench.md) |
-| Operate or test the Hermes/ToolHive workbench | [AI Workbench](operations/ai-workbench.md)                           |
-| Understand backup posture or Kopiur migration | [Storage and Backups](operations/storage-and-backups.md)             |
+| Need                                           | Read or update                                                                       |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Understand repo layout, validation, and peers  | [Repo Guide](guides/repo-guide.md)                                                   |
+| Understand the AI workbench architecture       | [ADR-0001: AI Home-Ops Workbench](adr/0001-ai-home-ops-workbench.md)                 |
+| Understand the backup storage decisions        | [ADR-0002: Kopiur Backend and Remote Shape](adr/0002-kopiur-backup-storage-shape.md) |
+| Operate or test the Hermes/ToolHive workbench  | [AI Workbench](operations/ai-workbench.md)                                           |
+| Understand backup posture or Kopiur migration  | [Storage and Backups](operations/storage-and-backups.md)                             |
+| Renew or replace appliance management TLS      | [Appliance TLS](operations/appliance-tls.md)                                         |
+| Reach the cluster when DNS or the router fails | [Talos Access and Break-Glass](operations/talos-access-and-break-glass.md)           |
 
 ## Placement Rule
 


### PR DESCRIPTION
Docs-currency pass: the docs map and the README operations list were missing the appliance TLS and Talos break-glass docs and ADR-0002; the README platform list now notes the in-progress Kopiur adoption alongside VolSync. No operational content changed.