### PR TITLE
fix(snapshot-controller): migrate to home operations chart

### DIFF
--- a/kubernetes/apps/kube-system/snapshot-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/app/helmrelease.yaml
@@ -21,8 +21,6 @@ spec:
               kind: CustomResourceDefinition
               version: v1
   values:
-    controller:
+    monitoring:
       serviceMonitor:
-        create: true
-    webhook:
-      enabled: false
+        enabled: true

--- a/kubernetes/apps/kube-system/snapshot-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/app/helmrelease.yaml
@@ -21,6 +21,7 @@ spec:
               kind: CustomResourceDefinition
               version: v1
   values:
+    replicaCount: 2
     monitoring:
       serviceMonitor:
         enabled: true

--- a/kubernetes/apps/kube-system/snapshot-controller/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 5.2.0
-  url: oci://ghcr.io/piraeusdatastore/helm-charts/snapshot-controller
+    tag: 0.1.0
+  url: oci://ghcr.io/home-operations/charts/snapshot-controller


### PR DESCRIPTION
## Summary

- replace the Piraeus snapshot-controller chart with Home Operations 0.1.0
- run two controller replicas with leader election
- translate ServiceMonitor configuration to the new values schema
- retain the CRD keep safeguard through the initial cutover

## Preflight

- stage 1 reconciled successfully on Piraeus 5.2.0
- all six snapshot CRDs are protected and use the upstream None conversion strategy
- the conversion webhook is absent and existing snapshots are healthy
- rendered Deployment and Service selectors match the live immutable selectors
- old and new controller RBAC rules are equivalent

## Validation

- mise exec -- oxfmt --check on both changed manifests
- mise exec -- flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets
- targeted Home Operations CRD and workload rendering

## Risk and rollback

The replacement chart is still at 0.1.0. The destructive CRD-prune path is mitigated by the previously reconciled keep annotations. If the upgrade fails, Flux can roll back to the protected Piraeus revision. After a successful cutover, verify CRD presence, snapshot readiness, controller health, and ServiceMonitor discovery before removing the now-inert post-renderer in a later cleanup.