### PR TITLE
fix(snapshot-controller): restore Piraeus chart

### DIFF
--- a/kubernetes/apps/kube-system/snapshot-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/app/helmrelease.yaml
@@ -21,7 +21,9 @@ spec:
               kind: CustomResourceDefinition
               version: v1
   values:
-    replicaCount: 2
-    monitoring:
+    controller:
+      replicaCount: 2
       serviceMonitor:
-        enabled: true
+        create: true
+    webhook:
+      enabled: false

--- a/kubernetes/apps/kube-system/snapshot-controller/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.1.0
-  url: oci://ghcr.io/home-operations/charts/snapshot-controller
+    tag: 5.2.0
+  url: oci://ghcr.io/piraeusdatastore/helm-charts/snapshot-controller


### PR DESCRIPTION
## Summary

- restore the Piraeus snapshot-controller chart at 5.2.0
- keep the conversion webhook disabled
- retain the CRD keep policy during recovery
- run two controller replicas

## Context

The native-CRD chart migration encountered a Helm ownership handoff failure and removed the snapshot CRDs. This restores the last known-good chart so Flux can recreate the APIs before attempting a staged migration again.

## Validation

- oxfmt check passed
- flate full cluster validation: 210 passed
- rendered six snapshot CRDs with the keep policy and no conversion webhook
- rendered the controller Deployment with two replicas