### PR TITLE
fix(snapshot-controller): install Home Operations chart

### DIFF
--- a/kubernetes/apps/kube-system/snapshot-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/app/helmrelease.yaml
@@ -9,21 +9,8 @@ spec:
     kind: OCIRepository
     name: snapshot-controller
   interval: 1h
-  postRenderers:
-    - kustomize:
-        patches:
-          - patch: |-
-              - op: add
-                path: /metadata/annotations/helm.sh~1resource-policy
-                value: keep
-            target:
-              group: apiextensions.k8s.io
-              kind: CustomResourceDefinition
-              version: v1
   values:
-    controller:
-      replicaCount: 2
+    replicaCount: 2
+    monitoring:
       serviceMonitor:
-        create: true
-    webhook:
-      enabled: false
+        enabled: true

--- a/kubernetes/apps/kube-system/snapshot-controller/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 5.2.0
-  url: oci://ghcr.io/piraeusdatastore/helm-charts/snapshot-controller
+    tag: 0.1.0
+  url: oci://ghcr.io/home-operations/charts/snapshot-controller


### PR DESCRIPTION
## Summary

- switch snapshot-controller to the Home Operations chart at 0.1.0
- run two controller replicas
- enable the chart ServiceMonitor
- remove the Piraeus-only CRD keep post-renderer

## Migration

This PR will be merged only after the existing Piraeus Helm release is suspended and uninstalled with its six kept CRDs verified intact. Flux will then reconcile this chart as a fresh install, avoiding an in-place templated-to-native CRD ownership transition.

## Validation

- oxfmt check passed
- flate full cluster validation: 210 passed
- rendered six native snapshot CRDs
- rendered no conversion webhook resources
- rendered the controller Deployment with two replicas