### PR TITLE
feat(kopiur): add production cluster repositories and app components

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 namespace: default
 components:
   - ../../components/alerts
+  - ../../components/kopiur/secrets
   - ../../components/sops
 resources:
   - ./namespace.yaml

--- a/kubernetes/apps/kopiur-system/kopiur/ks.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/ks.yaml
@@ -14,3 +14,25 @@ spec:
     namespace: flux-system
   targetNamespace: kopiur-system
   wait: true
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kopiur-repositories
+spec:
+  dependsOn:
+    - name: kopiur
+  interval: 1h
+  path: ./kubernetes/apps/kopiur-system/kopiur/repository
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: kopiur-system
+  wait: false

--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository-local.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository-local.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/clusterrepository_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: ClusterRepository
+metadata:
+  name: local
+spec:
+  # Production local backend per ADR-0002: Garage S3 on the NAS, so backup IO
+  # never traverses nfsd (the nfs_probe/zeroscaler guardrail path).
+  allowedNamespaces:
+    list:
+      - default
+  backend:
+    s3:
+      auth:
+        secretRef:
+          name: kopiur-local-secret
+          namespace: kopiur-system
+      bucket: kopiur
+      endpoint: garage.internal:3900
+      region: garage
+      tls:
+        disableTls: true
+  create:
+    enabled: true
+  deletionProtection:
+    threshold: 10
+  encryption:
+    passwordSecretRef:
+      name: kopiur-local-secret
+      namespace: kopiur-system
+      key: KOPIA_PASSWORD
+  maintenance:
+    schedule:
+      # Full maintenance out of the H 3 remote-snapshot window; quick keeps
+      # the 6-hourly default.
+      full:
+        cron: "H 4 * * *"
+  scheduleDefaults:
+    timezone: Pacific/Auckland

--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository-local.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository-local.yaml
@@ -32,8 +32,11 @@ spec:
       key: KOPIA_PASSWORD
   maintenance:
     schedule:
-      # Full maintenance out of the H 3 remote-snapshot window; quick keeps
-      # the 6-hourly default.
+      # Both blocks are required once schedule is set; quick reproduces the
+      # operator default, full moves out of the H 3 remote-snapshot window.
+      quick:
+        cron: "0 */6 * * *"
+        jitter: 30m
       full:
         cron: "H 4 * * *"
   scheduleDefaults:

--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository-remote.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository-remote.yaml
@@ -31,7 +31,11 @@ spec:
       key: KOPIA_PASSWORD
   maintenance:
     schedule:
-      # Staggered after the local repository's full run (H 4).
+      # Both blocks are required once schedule is set; quick reproduces the
+      # operator default, full staggers after the local repository's (H 4).
+      quick:
+        cron: "0 */6 * * *"
+        jitter: 30m
       full:
         cron: "H 5 * * *"
   scheduleDefaults:

--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository-remote.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository-remote.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/clusterrepository_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: ClusterRepository
+metadata:
+  name: remote
+spec:
+  # Independent R2 repository per ADR-0002: own credentials, encryption
+  # password, cadence, retention, and maintenance — no RepositoryReplication,
+  # no shared corruption domain with the local repository.
+  allowedNamespaces:
+    list:
+      - default
+  backend:
+    s3:
+      auth:
+        secretRef:
+          name: kopiur-remote-secret
+          namespace: kopiur-system
+      bucket: kopiur
+      endpoint: "${SECRET_KOPIUR_R2_ENDPOINT}"
+      region: auto
+  create:
+    enabled: true
+  deletionProtection:
+    threshold: 10
+  encryption:
+    passwordSecretRef:
+      name: kopiur-remote-secret
+      namespace: kopiur-system
+      key: KOPIA_PASSWORD
+  maintenance:
+    schedule:
+      # Staggered after the local repository's full run (H 4).
+      full:
+        cron: "H 5 * * *"
+  scheduleDefaults:
+    timezone: Pacific/Auckland

--- a/kubernetes/apps/kopiur-system/kopiur/repository/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./clusterrepository-local.yaml
+  - ./clusterrepository-remote.yaml

--- a/kubernetes/apps/kopiur-system/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kustomization.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 namespace: kopiur-system
 components:
   - ../../components/alerts
+  - ../../components/kopiur/secrets
+  - ../../components/sops
 resources:
   - ./namespace.yaml
   - ./kopiur/ks.yaml

--- a/kubernetes/components/kopiur/local/kustomization.yaml
+++ b/kubernetes/components/kopiur/local/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./snapshotpolicy.yaml
+  - ./snapshotschedule.yaml

--- a/kubernetes/components/kopiur/local/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/local/snapshotpolicy.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: "${APP}"
+spec:
+  repository:
+    kind: ClusterRepository
+    name: local
+  sources:
+    - pvc:
+        name: "${APP}"
+  # Explicit rather than defaulted: the upstream default shifted once already
+  # (Direct -> Snapshot) and this field decides whether the app PVC is read
+  # live or from a CSI snapshot.
+  copyMethod: Snapshot
+  volumeSnapshotClassName: "${KOPIUR_SNAPSHOTCLASS:=csi-ceph-blockpool}"
+  compression:
+    compressor: zstd
+  retention:
+    keepLatest: 3
+    keepHourly: 24
+    keepDaily: 7
+    keepWeekly: 4
+  mover:
+    securityContext:
+      runAsUser: ${KOPIUR_PUID:=1032}
+      runAsGroup: ${KOPIUR_PGID:=100}
+    cache:
+      capacity: "${KOPIUR_CACHE_CAPACITY:=5Gi}"
+      mode: Persistent
+      storageClassName: ceph-block

--- a/kubernetes/components/kopiur/local/snapshotschedule.yaml
+++ b/kubernetes/components/kopiur/local/snapshotschedule.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotschedule_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: "${APP}"
+spec:
+  policyRef:
+    name: "${APP}"
+  schedule:
+    # H hashes a deterministic per-app minute so the fleet spreads across the
+    # hour instead of stampeding; timezone inherits from the repository.
+    cron: "H * * * *"
+    runOnCreate: false

--- a/kubernetes/components/kopiur/remote/kustomization.yaml
+++ b/kubernetes/components/kopiur/remote/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./snapshotpolicy.yaml
+  - ./snapshotschedule.yaml

--- a/kubernetes/components/kopiur/remote/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/remote/snapshotpolicy.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: "${APP}-remote"
+spec:
+  repository:
+    kind: ClusterRepository
+    name: remote
+  sources:
+    - pvc:
+        name: "${APP}"
+  # Explicit rather than defaulted: the upstream default shifted once already
+  # (Direct -> Snapshot) and this field decides whether the app PVC is read
+  # live or from a CSI snapshot.
+  copyMethod: Snapshot
+  volumeSnapshotClassName: "${KOPIUR_SNAPSHOTCLASS:=csi-ceph-blockpool}"
+  compression:
+    compressor: zstd
+  # Leaner GFS than local: the independent cadence and retention is the point
+  # of ADR-0002's remote shape.
+  retention:
+    keepDaily: 7
+    keepWeekly: 4
+    keepMonthly: 3
+  mover:
+    securityContext:
+      runAsUser: ${KOPIUR_PUID:=1032}
+      runAsGroup: ${KOPIUR_PGID:=100}
+    cache:
+      capacity: "${KOPIUR_REMOTE_CACHE_CAPACITY:=2Gi}"
+      mode: Persistent
+      storageClassName: ceph-block

--- a/kubernetes/components/kopiur/remote/snapshotschedule.yaml
+++ b/kubernetes/components/kopiur/remote/snapshotschedule.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotschedule_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: "${APP}-remote"
+spec:
+  policyRef:
+    name: "${APP}-remote"
+  schedule:
+    # Daily in the H 3 window, disjoint from VolSync remote (00:30) and from
+    # both repositories' full maintenance (H 4 local, H 5 remote); timezone
+    # inherits from the repository.
+    cron: "H 3 * * *"
+    runOnCreate: false

--- a/kubernetes/components/kopiur/secrets/externalsecret.yaml
+++ b/kubernetes/components/kopiur/secrets/externalsecret.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kopiur-local
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: kopiur-local-secret
+    template:
+      data:
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+        KOPIA_PASSWORD: "{{ .KOPIA_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: kopiur-local
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kopiur-remote
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: kopiur-remote-secret
+    template:
+      data:
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+        KOPIA_PASSWORD: "{{ .KOPIA_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: kopiur-remote

--- a/kubernetes/components/kopiur/secrets/kustomization.yaml
+++ b/kubernetes/components/kopiur/secrets/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./externalsecret.yaml

--- a/kubernetes/components/sops/cluster-secrets.sops.yaml
+++ b/kubernetes/components/sops/cluster-secrets.sops.yaml
@@ -5,14 +5,10 @@ metadata:
     name: cluster-secrets
 stringData:
     SECRET_DOMAIN: ENC[AES256_GCM,data:g3trRqPZzSkUm866Y3M4sg==,iv:RnjRY+fPRIBdZGv2xyWp6DMmxg4tosb/zgOsuE40f1A=,tag:/j2vuJXaXqmJDRFzUnNJ8g==,type:str]
+    SECRET_KOPIUR_R2_ENDPOINT: ENC[AES256_GCM,data:fdpdPUf7xggiu9oWxMdt9TZhbkbX/CzIpgrRsz3FSZ4s2LgZFoTQx9ZJxBUULQsTmuS6ppJfdOOj,iv:cClTlTpnc5tnwo4W8FDr7ZHXHOQQ3IQtXawUf8KxsSY=,tag:8Sy5lRClptOTmiusMX0owg==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
     age:
-        - recipient: age1vrlh74rr2ph4l7t07nhq0qmlwnm4ykckyhaf3teutxe437c6s4wsrf37mg
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqZmFmT2laK2RDYVgya3VH
             eXZMODRBamFkNXNGeElJV3FQTVZORUV4UmpNCmdPU3BONVB3Q2ZlZjBqaTNoUVJZ
@@ -20,9 +16,9 @@ sops:
             dEQ4YkNVejBYQWRSU3F4OWZ4TDRSYUEK977gOVmWtPEB4HQantdPxo7vhlMFxpfo
             vHzIt8o0MbOQHlQ69y+MQfXIuRAEZr6I5pFEqb13hEcKH5ir74U/jg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-03-25T01:14:57Z"
-    mac: ENC[AES256_GCM,data:On2xaEWFGFj9sVclgMdj6XjxcV4wE1FvsEvi081QRmmrKJvM/yknrpG/wXUylthJIWqGcM00AmIR71Ro4znvfpOM3o7WXwboctZEunnF+aVJibHVaHrZZuYuFl3ge1oGz4RDJoQPpGGN4sIrHJDFzOm9jlBgGTW6TVYi4ygQ8oY=,iv:/Cfbew4aOlBYwT43uH88RKENYoRREviq1xUwTMghPNw=,tag:FI5DIDalKG00Iq2/S528Eg==,type:str]
-    pgp: []
+          recipient: age1vrlh74rr2ph4l7t07nhq0qmlwnm4ykckyhaf3teutxe437c6s4wsrf37mg
     encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-22T09:51:41Z"
+    mac: ENC[AES256_GCM,data:hKjfaGcx5t9UbQUwpUnkVidgZ/ag07PY6AnFkMRqQ9oZ4UmbeB1slOkMM+6H5BspUwEPH8GNnD6VhwD/EDcuGtF9Zj0qNRnU2rbN6nkkNkdYy7h7IFS6N14qNOOo7/B+9b+Ui3jqHV6kF13Y1oJQjuqVVUCHmCaZAMfSG3LvVgA=,iv:ClGFfhJ/WAV2YEFcJs07DB6ycTsODZD7LsoGRyCOq7s=,tag:EsNlS7HAM7MpDhZpav0xQw==,type:str]
     mac_only_encrypted: true
-    version: 3.9.4
+    version: 3.13.2


### PR DESCRIPTION
Phase 1 of the #1487 production rollout, per ADR-0002. Repository resources and reusable components only — **no app changes**; nothing consumes either repository yet.

## What

- `ClusterRepository/local` — S3 backend on the LAN object store selected by ADR-0002, `allowedNamespaces` restricted to `default`, full maintenance staggered to the H 4 window.
- `ClusterRepository/remote` — independent R2 repository (own credentials, encryption password, cadence, retention; no `RepositoryReplication`), endpoint substituted from cluster-secrets, full maintenance H 5.
- `components/kopiur/secrets` — the two repository ExternalSecrets, included at namespace level in `default` and `kopiur-system` (movers resolve the same-named Secret namespace-locally; credential projection stays off).
- `components/kopiur/local` / `components/kopiur/remote` — reusable per-app SnapshotPolicy + SnapshotSchedule pairs mirroring the VolSync component split: local hourly `H * * * *` with keepLatest 3 / hourly 24 / daily 7 / weekly 4; remote daily `H 3 * * *` with daily 7 / weekly 4 / monthly 3. Explicit `copyMethod: Snapshot` and `runOnCreate: false` throughout.
- New `kopiur-repositories` Flux Kustomization (dependsOn `kopiur`), sops component added to `kopiur-system` for the substitution, and one new cluster-secrets key.

## Validation

- `oxfmt --check` clean.
- `kubectl kustomize` renders for `kopiur-system`, `default`, and the repository directory.
- `flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets`: 211 passed (single pre-existing unrelated warning).
- Both ClusterRepositories structurally validated against the pinned Kopiur 0.8.0 JSON schemas, including required-field checks (a review pass caught that `maintenance.schedule` requires both `quick` and `full` — fixed in 2978b58b; render checks alone do not perform CRD admission validation, so a negative test was run to confirm the validator catches the omission).

## Merge effect and rollback

Merging is additive but not fully inert: the operator will initialise both repositories (writing Kopia repository metadata into each bucket) and create their managed Maintenance resources on the H 4 / H 5 + 6-hourly quick schedules. No application snapshots are taken until an app adopts the components (Phase 2).

Rollback: revert this PR — all Kubernetes resources are removed; the small amount of repository metadata already written to the buckets is not erased by the revert and can be cleaned bucket-side if ever needed.