### PR TITLE
feat(kopiur): enable production backups for bazarr

### DIFF
--- a/kubernetes/apps/default/bazarr/ks.yaml
+++ b/kubernetes/apps/default/bazarr/ks.yaml
@@ -6,6 +6,8 @@ metadata:
   name: bazarr
 spec:
   components:
+    - ../../../../components/kopiur/local
+    - ../../../../components/kopiur/remote
     - ../../../../components/volsync
     - ../../../../components/zeroscaler
   dependsOn:


### PR DESCRIPTION
Phase 2b of #1487 — **merge order: #1595 (hotfix) → #1593 (2a) → this**.

Stacked on the #1593 branch. Because this repo squash-merges, the three-dot PR diff will NOT collapse on its own when #1593 merges: after #1593 lands, this branch gets rebased onto the new `main` and force-pushed with `--force-with-lease`, then verified — base `main`, diff exactly the two component lines, full Lint/Image Pull checks running (currently limited because the PR targets the stacked branch). It stays draft until then.

Attaches `components/kopiur/local` and `components/kopiur/remote` to the bazarr Kustomization — the same two-line shape the Phase 3 fleet PR will replicate per app. Renders four resources into `default`: SnapshotPolicy + SnapshotSchedule `bazarr` (ClusterRepository `local`, hourly `H`, keepLatest 3 / hourly 24 / daily 7 / weekly 4) and `bazarr-remote` (ClusterRepository `remote`, daily `H 3`, daily 7 / weekly 4 / monthly 3). Explicit `copyMethod: Snapshot` and `runOnCreate: false`; mover identity 1032:100; VolSync untouched.

This starts the Phase 2 acceptance clock: ≥3 consecutive green days on both legs, timed restores from both repositories into temp PVCs with db integrity checks, maintenance runtimes on both (maintenance itself is repository-level and starts with #1595, not this PR — runs after bazarr enablement count as acceptance evidence), `nfs_probe` clean across every window, zero zeroscaler events including a deliberate restore during playback. Immediately after merge: inspect both schedules' resolved `nextSchedule`/timezone before their first firing (the pilot's first run fired on UTC once).

## Validation

- `flate test all`: 210 passed; rendered output inspected — all four CRs substitute correctly.
- Rendered CRs structurally validated against the pinned 0.8.0 JSON schemas (required-field checks included).

## Rollback

Revert the PR — the policies/schedules are pruned with the 0.8.0 `Retain` cascade defaults, and VolSync coverage never stopped.