### PR TITLE
fix(kopiur): allow operator namespace for managed maintenance

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository-local.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository-local.yaml
@@ -7,9 +7,12 @@ metadata:
 spec:
   # Production local backend per ADR-0002: Garage S3 on the NAS, so backup IO
   # never traverses nfsd (the nfs_probe/zeroscaler guardrail path).
+  # kopiur-system must be allowed: the managed Maintenance CR lands in the
+  # operator namespace, and the allowlist gates it too.
   allowedNamespaces:
     list:
       - default
+      - kopiur-system
   backend:
     s3:
       auth:

--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository-remote.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository-remote.yaml
@@ -8,9 +8,12 @@ spec:
   # Independent R2 repository per ADR-0002: own credentials, encryption
   # password, cadence, retention, and maintenance — no RepositoryReplication,
   # no shared corruption domain with the local repository.
+  # kopiur-system must be allowed: the managed Maintenance CR lands in the
+  # operator namespace, and the allowlist gates it too.
   allowedNamespaces:
     list:
       - default
+      - kopiur-system
   backend:
     s3:
       auth:


### PR DESCRIPTION
Hotfix for #1592, prerequisite to the Phase 2 PRs (#1593/#1594).

Both production ClusterRepositories are `Ready` but report `MaintenanceConfigured=False` / `MaintenanceApplyFailed` with no managed Maintenance CRs: the managed Maintenance resource lands in the operator namespace, and `allowedNamespaces` gates that placement too — restricting the list to `default` alone was incomplete. Adds `kopiur-system` to both lists; still least-privilege (no `all: true`). The corrected objects passed a server-side dry run against the live cluster.

## Acceptance (post-merge)

- `MaintenanceConfigured=True` on both repositories
- two managed Maintenance CRs present in the operator namespace with the expected quick (6-hourly + 30m jitter) and full (H 4 / H 5) schedules
- no continuing controller warnings

## Rollback

Revert — restores the previous (maintenance-broken but otherwise harmless) state.