### PR TITLE
test(kopiur): verify bazarr local restore

### DIFF
--- a/kubernetes/apps/default/bazarr/app/kustomization.yaml
+++ b/kubernetes/apps/default/bazarr/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./restore-drill.yaml

--- a/kubernetes/apps/default/bazarr/app/restore-drill.yaml
+++ b/kubernetes/apps/default/bazarr/app/restore-drill.yaml
@@ -1,0 +1,123 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/restore_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: bazarr-restore-local-drill
+spec:
+  source:
+    fromPolicy:
+      name: bazarr
+      offset: 0
+  target:
+    populator: {}
+  policy:
+    onMissingSnapshot: Fail
+  mover:
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1032
+      runAsGroup: 100
+    podSecurityContext:
+      fsGroup: 100
+      fsGroupChangePolicy: OnRootMismatch
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bazarr-restore-local-drill
+spec:
+  accessModes:
+    - ReadWriteOnce
+  dataSourceRef:
+    apiGroup: kopiur.home-operations.com
+    kind: Restore
+    name: bazarr-restore-local-drill
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: ceph-block
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: bazarr-restore-local-drill-validate
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bazarr-restore-local-drill
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1032
+        runAsGroup: 100
+        fsGroup: 100
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: validate
+          image: ghcr.io/home-operations/bazarr:1.6.0@sha256:cd63bbd0986c93e238eb8b9442604d249f0d4080099b389f822abe2062044417
+          command:
+            - python3
+            - -c
+          args:
+            - |
+              import collections
+              import os
+              import shutil
+              import sqlite3
+
+              root = "/restore"
+              rows = []
+              for base, _, files in os.walk(root):
+                  for name in files:
+                      stat = os.lstat(os.path.join(base, name))
+                      rows.append((stat.st_uid, stat.st_gid, stat.st_size))
+
+              owners = collections.Counter((uid, gid) for uid, gid, _ in rows)
+              source_db = os.path.join(root, "db", "bazarr.db")
+              scratch_db = "/tmp/bazarr.db"
+              for suffix in ("", "-wal", "-shm"):
+                  source = source_db + suffix
+                  if os.path.exists(source):
+                      shutil.copy2(source, scratch_db + suffix)
+
+              connection = sqlite3.connect(scratch_db)
+              integrity = connection.execute("PRAGMA integrity_check").fetchone()[0]
+              connection.close()
+
+              print(f"files={len(rows)} bytes={sum(size for _, _, size in rows)}")
+              print(
+                  "owners="
+                  + ",".join(
+                      f"{uid}:{gid}={count}"
+                      for (uid, gid), count in sorted(owners.items())
+                  )
+              )
+              print(f"integrity_check={integrity}")
+
+              if len(rows) != 21:
+                  raise SystemExit("unexpected restored file count")
+              if owners != collections.Counter({(1032, 100): 21}):
+                  raise SystemExit("unexpected restored ownership")
+              if integrity != "ok":
+                  raise SystemExit("restored database integrity check failed")
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: ["ALL"] }
+          volumeMounts:
+            - name: restore
+              mountPath: /restore
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: restore
+          persistentVolumeClaim:
+            claimName: bazarr-restore-local-drill
+            readOnly: true
+        - name: tmp
+          emptyDir: {}


### PR DESCRIPTION
## Summary

- restore the latest Bazarr snapshot from the local repository into an isolated 5 GiB populator PVC
- validate file count, ownership, and SQLite integrity with a read-only one-shot Job
- leave the production PVC and application deployment untouched

This is a temporary Phase 2 acceptance drill. A cleanup PR will prune all three test resources after evidence is collected.

## Validation

- live Restore CRD admission and `kubectl apply --dry-run=server`
- `mise exec -- flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets` — 210 passed
- `mise exec -- flate diff images -p ./kubernetes/flux/cluster -o json` — no image changes
- `mise exec -- oxfmt --check ...`

## Merge effect

Flux creates the passive Restore, its isolated PVC, and the validation Job. The Job can start only after the populator has completed and mounts the restored PVC read-only.

## Rollback

Remove `restore-drill.yaml` from the app Kustomization and delete the file in the cleanup PR. Flux prunes the temporary Restore, PVC, Job, and restored test data; production data is never referenced.