### PR TITLE
feat(kopiur): enable fleet backups

### DIFF
--- a/kubernetes/apps/default/agregarr/ks.yaml
+++ b/kubernetes/apps/default/agregarr/ks.yaml
@@ -6,6 +6,8 @@ metadata:
   name: agregarr
 spec:
   components:
+    - ../../../../components/kopiur/local
+    - ../../../../components/kopiur/remote
     - ../../../../components/volsync
   dependsOn:
     - name: rook-ceph-cluster

--- a/kubernetes/apps/default/atuin/ks.yaml
+++ b/kubernetes/apps/default/atuin/ks.yaml
@@ -6,6 +6,8 @@ metadata:
   name: atuin
 spec:
   components:
+    - ../../../../components/kopiur/local
+    - ../../../../components/kopiur/remote
     - ../../../../components/volsync
   dependsOn:
     - name: rook-ceph-cluster

--- a/kubernetes/apps/default/autobrr/ks.yaml
+++ b/kubernetes/apps/default/autobrr/ks.yaml
@@ -6,6 +6,8 @@ metadata:
   name: autobrr
 spec:
   components:
+    - ../../../../components/kopiur/local
+    - ../../../../components/kopiur/remote
     - ../../../../components/volsync
   dependsOn:
     - name: rook-ceph-cluster

--- a/kubernetes/apps/default/brrpolice/ks.yaml
+++ b/kubernetes/apps/default/brrpolice/ks.yaml
@@ -6,6 +6,8 @@ metadata:
   name: brrpolice
 spec:
   components:
+    - ../../../../components/kopiur/local
+    - ../../../../components/kopiur/remote
     - ../../../../components/volsync
   dependsOn:
     - name: rook-ceph-cluster

--- a/kubernetes/apps/default/maintainerr/ks.yaml
+++ b/kubernetes/apps/default/maintainerr/ks.yaml
@@ -6,6 +6,8 @@ metadata:
   name: maintainerr
 spec:
   components:
+    - ../../../../components/kopiur/local
+    - ../../../../components/kopiur/remote
     - ../../../../components/volsync
   dependsOn:
     - name: rook-ceph-cluster

--- a/kubernetes/apps/default/plex/ks.yaml
+++ b/kubernetes/apps/default/plex/ks.yaml
@@ -6,6 +6,8 @@ metadata:
   name: plex
 spec:
   components:
+    - ../../../../components/kopiur/local
+    - ../../../../components/kopiur/remote
     - ../../../../components/volsync
     - ../../../../components/zeroscaler
   dependsOn:

--- a/kubernetes/apps/default/prowlarr/ks.yaml
+++ b/kubernetes/apps/default/prowlarr/ks.yaml
@@ -6,6 +6,8 @@ metadata:
   name: prowlarr
 spec:
   components:
+    - ../../../../components/kopiur/local
+    - ../../../../components/kopiur/remote
     - ../../../../components/volsync
   dependsOn:
     - name: rook-ceph-cluster

--- a/kubernetes/apps/default/qbittorrent/ks.yaml
+++ b/kubernetes/apps/default/qbittorrent/ks.yaml
@@ -6,6 +6,8 @@ metadata:
   name: qbittorrent
 spec:
   components:
+    - ../../../../components/kopiur/local
+    - ../../../../components/kopiur/remote
     - ../../../../components/volsync
     - ../../../../components/zeroscaler
   dependsOn:

--- a/kubernetes/apps/default/qui/ks.yaml
+++ b/kubernetes/apps/default/qui/ks.yaml
@@ -6,6 +6,8 @@ metadata:
   name: qui
 spec:
   components:
+    - ../../../../components/kopiur/local
+    - ../../../../components/kopiur/remote
     - ../../../../components/volsync
     - ../../../../components/zeroscaler
   dependsOn:

--- a/kubernetes/apps/default/radarr-se/ks.yaml
+++ b/kubernetes/apps/default/radarr-se/ks.yaml
@@ -6,6 +6,8 @@ metadata:
   name: radarr-se
 spec:
   components:
+    - ../../../../components/kopiur/local
+    - ../../../../components/kopiur/remote
     - ../../../../components/volsync
     - ../../../../components/zeroscaler
   dependsOn:

--- a/kubernetes/apps/default/radarr/ks.yaml
+++ b/kubernetes/apps/default/radarr/ks.yaml
@@ -6,6 +6,8 @@ metadata:
   name: radarr
 spec:
   components:
+    - ../../../../components/kopiur/local
+    - ../../../../components/kopiur/remote
     - ../../../../components/volsync
     - ../../../../components/zeroscaler
   dependsOn:

--- a/kubernetes/apps/default/recyclarr/ks.yaml
+++ b/kubernetes/apps/default/recyclarr/ks.yaml
@@ -6,6 +6,8 @@ metadata:
   name: recyclarr
 spec:
   components:
+    - ../../../../components/kopiur/local
+    - ../../../../components/kopiur/remote
     - ../../../../components/volsync
   dependsOn:
     - name: rook-ceph-cluster

--- a/kubernetes/apps/default/resolute/ks.yaml
+++ b/kubernetes/apps/default/resolute/ks.yaml
@@ -6,6 +6,8 @@ metadata:
   name: resolute
 spec:
   components:
+    - ../../../../components/kopiur/local
+    - ../../../../components/kopiur/remote
     - ../../../../components/volsync
   dependsOn:
     - name: rook-ceph-cluster

--- a/kubernetes/apps/default/sabnzbd/ks.yaml
+++ b/kubernetes/apps/default/sabnzbd/ks.yaml
@@ -6,6 +6,8 @@ metadata:
   name: sabnzbd
 spec:
   components:
+    - ../../../../components/kopiur/local
+    - ../../../../components/kopiur/remote
     - ../../../../components/volsync
     - ../../../../components/zeroscaler
   dependsOn:

--- a/kubernetes/apps/default/seerr/ks.yaml
+++ b/kubernetes/apps/default/seerr/ks.yaml
@@ -6,6 +6,8 @@ metadata:
   name: seerr
 spec:
   components:
+    - ../../../../components/kopiur/local
+    - ../../../../components/kopiur/remote
     - ../../../../components/volsync
   dependsOn:
     - name: rook-ceph-cluster

--- a/kubernetes/apps/default/sonarr/ks.yaml
+++ b/kubernetes/apps/default/sonarr/ks.yaml
@@ -6,6 +6,8 @@ metadata:
   name: sonarr
 spec:
   components:
+    - ../../../../components/kopiur/local
+    - ../../../../components/kopiur/remote
     - ../../../../components/volsync
     - ../../../../components/zeroscaler
   dependsOn:

--- a/kubernetes/apps/default/tautulli/ks.yaml
+++ b/kubernetes/apps/default/tautulli/ks.yaml
@@ -6,6 +6,8 @@ metadata:
   name: tautulli
 spec:
   components:
+    - ../../../../components/kopiur/local
+    - ../../../../components/kopiur/remote
     - ../../../../components/volsync
   dependsOn:
     - name: rook-ceph-cluster

--- a/kubernetes/apps/default/thelounge/ks.yaml
+++ b/kubernetes/apps/default/thelounge/ks.yaml
@@ -6,6 +6,8 @@ metadata:
   name: thelounge
 spec:
   components:
+    - ../../../../components/kopiur/local
+    - ../../../../components/kopiur/remote
     - ../../../../components/volsync
   dependsOn:
     - name: rook-ceph-cluster


### PR DESCRIPTION
## Summary

- add the local and independent remote Kopiur components to the remaining 18 VolSync-backed apps
- retain all existing VolSync objects, PVCs, restore wiring, and schedules
- progress #1487 into the seven-day fleet soak

## Rendered shape

- 18 `ks.yaml` files, 36 additions, no other source changes
- 72 new objects: 36 `SnapshotPolicy` and 36 `SnapshotSchedule` resources
- local schedules use `H * * * *`; remote schedules use `H 3 * * *`
- every schedule has `runOnCreate: false`
- every policy uses CSI `Snapshot` copy, the expected repository, retention, cache, and `1032:100` mover identity
- no `Restore`, PVC, VolSync, or container-image changes

## Preflight and validation

- all 19 protected source PVCs are bound
- both repositories are Ready with maintenance configured
- namespace credential resources are Ready
- all 19 workload identities match the mover identity
- all 76 rendered fleet policies and schedules pass strict server-side dry-run against the live 0.8.0 CRDs
- `mise exec -- oxfmt --check kubernetes/apps/default/*/ks.yaml`
- `mise exec -- flate test all` — 210 passed
- `mise exec -- flate diff ks --base origin/main -p ./kubernetes/flux/cluster -n default -o brief --allow-missing-secrets` — 72 additions only
- `mise exec -- flate diff images -p ./kubernetes/flux/cluster --base origin/main -o json` — `[]`
- `git diff --check`

## Merge effect

Merging creates the 72 additive resources. Nothing snapshots on reconciliation: `runOnCreate` is false. First local runs arrive at deterministic hashed minutes in the following hourly windows; first remote runs arrive in the next hashed 03:00 window. VolSync continues throughout.

## Rollback

Revert the PR to remove all new policies and schedules, or remove an individual app’s two component lines. The default policy-deletion behaviour retains repository data; VolSync remains the independent backup and restore path.