### PR TITLE
test(kopiur): verify thelounge local restore

### DIFF
--- a/kubernetes/apps/default/thelounge/app/kustomization.yaml
+++ b/kubernetes/apps/default/thelounge/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./restore-drill.yaml

--- a/kubernetes/apps/default/thelounge/app/restore-drill.yaml
+++ b/kubernetes/apps/default/thelounge/app/restore-drill.yaml
@@ -1,0 +1,135 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/restore_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: thelounge-restore-local-drill
+spec:
+  source:
+    fromPolicy:
+      name: thelounge
+      offset: 0
+  target:
+    populator: {}
+  policy:
+    onMissingSnapshot: Fail
+  mover:
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1032
+      runAsGroup: 100
+    podSecurityContext:
+      fsGroup: 100
+      fsGroupChangePolicy: OnRootMismatch
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: thelounge-restore-local-drill
+spec:
+  accessModes:
+    - ReadWriteOnce
+  dataSourceRef:
+    apiGroup: kopiur.home-operations.com
+    kind: Restore
+    name: thelounge-restore-local-drill
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: ceph-block
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: thelounge-restore-local-drill-validate
+spec:
+  activeDeadlineSeconds: 3600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: thelounge-restore-local-drill
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1032
+        runAsGroup: 100
+        fsGroup: 100
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: validate
+          image: ghcr.io/home-operations/bazarr:1.6.0@sha256:cd63bbd0986c93e238eb8b9442604d249f0d4080099b389f822abe2062044417
+          command:
+            - python3
+            - -c
+          args:
+            - |
+              import collections
+              import os
+              import sqlite3
+
+              root = "/restore"
+              rows = []
+              databases = []
+              for base, _, files in os.walk(root):
+                  for name in files:
+                      path = os.path.join(base, name)
+                      stat = os.lstat(path)
+                      rows.append((stat.st_uid, stat.st_gid, stat.st_size))
+                      if not os.path.islink(path):
+                          with open(path, "rb") as stream:
+                              if stream.read(16) == b"SQLite format 3\x00":
+                                  databases.append(path)
+
+              owners = collections.Counter((uid, gid) for uid, gid, _ in rows)
+              integrity = []
+              for path in databases:
+                  connection = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+                  connection.execute("PRAGMA query_only = ON")
+                  integrity.append(connection.execute("PRAGMA integrity_check").fetchone()[0])
+                  connection.close()
+
+              print(f"files={len(rows)} bytes={sum(size for _, _, size in rows)}")
+              print(
+                  "owners="
+                  + ",".join(
+                      f"{uid}:{gid}={count}"
+                      for (uid, gid), count in sorted(owners.items())
+                  )
+              )
+              print(f"sqlite_databases={len(databases)}")
+              print("integrity_check=" + ",".join(integrity))
+
+              if not rows:
+                  raise SystemExit("restored filesystem is empty")
+              if set(owners) != {(1032, 100)}:
+                  raise SystemExit("unexpected restored ownership")
+              if len(databases) != 1:
+                  raise SystemExit("unexpected SQLite database count")
+              if integrity != ["ok"]:
+                  raise SystemExit("restored database integrity check failed")
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: ["ALL"] }
+          resources:
+            requests:
+              cpu: 10m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+          volumeMounts:
+            - name: restore
+              mountPath: /restore
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: restore
+          persistentVolumeClaim:
+            claimName: thelounge-restore-local-drill
+            readOnly: true
+        - name: tmp
+          emptyDir:
+            sizeLimit: 128Mi


### PR DESCRIPTION
## Summary

- restore TheLounge from the latest local Kopiur snapshot into a temporary PVC
- validate restored file ownership and SQLite integrity in an isolated, read-only Job
- leave the production workload and PVC untouched

## Validation

- `mise exec -- kubectl kustomize kubernetes/apps/default/thelounge/app`
- `mise exec -- flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets` (210 passed)
- server-side dry run of the rendered app bundle
- image diff contains only the pinned validation image

The temporary Restore, PVC, and Job will be removed in a follow-up cleanup after evidence is captured.