### PR TITLE
fix(kopiur): allow thelounge drill validation

### DIFF
--- a/kubernetes/apps/default/thelounge/app/restore-drill.yaml
+++ b/kubernetes/apps/default/thelounge/app/restore-drill.yaml
@@ -41,7 +41,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: thelounge-restore-local-drill-validate
+  name: thelounge-restore-local-drill-validate-v2
 spec:
   activeDeadlineSeconds: 3600
   backoffLimit: 0
@@ -122,14 +122,12 @@ spec:
           volumeMounts:
             - name: restore
               mountPath: /restore
-              readOnly: true
             - name: tmp
               mountPath: /tmp
       volumes:
         - name: restore
           persistentVolumeClaim:
             claimName: thelounge-restore-local-drill
-            readOnly: true
         - name: tmp
           emptyDir:
             sizeLimit: 128Mi


### PR DESCRIPTION
## Summary

- replace the failed disposable validation Job with a fresh Job name
- allow SQLite to create lock/shared-memory state on the temporary restored PVC
- keep the production workload and PVC untouched

## Finding

The Kopiur restore completed successfully. The first validator failed because SQLite could not open the crash-consistent database from a read-only mount.

## Validation

- app-level Kustomize render
- server-side dry run of the corrected bundle
- `git diff --check`