### PR TITLE
fix(kopiur): recover thelounge drill database

### DIFF
--- a/kubernetes/apps/default/thelounge/app/restore-drill.yaml
+++ b/kubernetes/apps/default/thelounge/app/restore-drill.yaml
@@ -41,7 +41,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: thelounge-restore-local-drill-validate-v2
+  name: thelounge-restore-local-drill-validate-v3
 spec:
   activeDeadlineSeconds: 3600
   backoffLimit: 0
@@ -85,8 +85,7 @@ spec:
               owners = collections.Counter((uid, gid) for uid, gid, _ in rows)
               integrity = []
               for path in databases:
-                  connection = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
-                  connection.execute("PRAGMA query_only = ON")
+                  connection = sqlite3.connect(path)
                   integrity.append(connection.execute("PRAGMA integrity_check").fetchone()[0])
                   connection.close()
 


### PR DESCRIPTION
## Summary

- replace the second failed disposable validator with a fresh Job
- remove the remaining read-only SQLite connection flags
- allow crash recovery only on the temporary restored PVC

## Finding

The restore is complete and healthy. The v2 PVC mount was writable, but the validator still opened SQLite with `mode=ro`, so recovery remained blocked.

## Validation

- app-level Kustomize render
- server-side dry run of the corrected bundle
- `git diff --check`