### PR TITLE
test(kopiur): verify plex remote restore

### DIFF
--- a/kubernetes/apps/default/plex/app/kustomization.yaml
+++ b/kubernetes/apps/default/plex/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./resourceclaimtemplate.yaml
+  - ./restore-drill-remote.yaml

--- a/kubernetes/apps/default/plex/app/restore-drill-remote.yaml
+++ b/kubernetes/apps/default/plex/app/restore-drill-remote.yaml
@@ -1,0 +1,134 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/restore_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: plex-restore-remote-drill
+spec:
+  source:
+    fromPolicy:
+      name: plex-remote
+      offset: 0
+  target:
+    populator: {}
+  policy:
+    onMissingSnapshot: Fail
+  mover:
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1032
+      runAsGroup: 100
+    podSecurityContext:
+      fsGroup: 100
+      fsGroupChangePolicy: OnRootMismatch
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: plex-restore-remote-drill
+spec:
+  accessModes:
+    - ReadWriteOnce
+  dataSourceRef:
+    apiGroup: kopiur.home-operations.com
+    kind: Restore
+    name: plex-restore-remote-drill
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: ceph-block
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: plex-restore-remote-drill-validate
+spec:
+  activeDeadlineSeconds: 3600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: plex-restore-remote-drill
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1032
+        runAsGroup: 100
+        fsGroup: 100
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: validate
+          image: ghcr.io/home-operations/plex:1.43.3.10828@sha256:0c0b6899339503af17cb190b25af6acf10f0030e2820985e16ee14ef428f49d7
+          command:
+            - sh
+            - -c
+          args:
+            - |
+              set -eu
+
+              stats="$(
+                find /restore \( -type f -o -type l \) -printf '%U:%G %s\n' |
+                  awk '
+                    {
+                      files++
+                      bytes += $2
+                      owners[$1]++
+                    }
+                    END {
+                      printf "files=%d bytes=%.0f\n", files, bytes
+                      printf "owners=1000:100=%d,1032:100=%d\n",
+                        owners["1000:100"], owners["1032:100"]
+                      if (
+                        files == 0 ||
+                        owners["1000:100"] == 0 ||
+                        owners["1032:100"] == 0 ||
+                        owners["1000:100"] + owners["1032:100"] != files
+                      ) {
+                        exit 1
+                      }
+                    }
+                  '
+              )"
+              printf '%s\n' "${stats}"
+
+              database_dir="/restore/Plug-in Support/Databases"
+              sqlite="/usr/lib/plexmediaserver/Plex SQLite"
+              for database in \
+                "${database_dir}/com.plexapp.plugins.library.db" \
+                "${database_dir}/com.plexapp.plugins.library.blobs.db"
+              do
+                if [ ! -f "${database}" ]; then
+                  echo "expected Plex database is missing"
+                  exit 1
+                fi
+                if [ "$("${sqlite}" "${database}" "PRAGMA integrity_check;")" != "ok" ]; then
+                  echo "restored Plex database integrity check failed"
+                  exit 1
+                fi
+              done
+
+              echo "sqlite_databases=2"
+              echo "integrity_check=ok,ok"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: ["ALL"] }
+          resources:
+            requests:
+              cpu: 10m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+          volumeMounts:
+            - name: restore
+              mountPath: /restore
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: restore
+          persistentVolumeClaim:
+            claimName: plex-restore-remote-drill
+        - name: tmp
+          emptyDir:
+            sizeLimit: 1Gi


### PR DESCRIPTION
## Summary

- restore Plex from the latest remote Kopiur snapshot into a temporary 50 GiB PVC
- validate restored file ownership and both Plex databases with the pinned Plex SQLite binary
- leave the production workload, application PVC, and cache PVC untouched

## Validation

- app-level Kustomize render
- embedded shell syntax and metadata-check smoke test
- full cluster render (210 passed)
- server-side dry run of the rendered app bundle
- cluster image diff is empty

The temporary Restore, PVC, and Job will be removed in a follow-up cleanup after evidence is captured.