### PR TITLE
fix(kopiur): escape plex drill variables

### DIFF
--- a/kubernetes/apps/default/plex/app/restore-drill-remote.yaml
+++ b/kubernetes/apps/default/plex/app/restore-drill-remote.yaml
@@ -90,19 +90,19 @@ spec:
                     }
                   '
               )"
-              printf '%s\n' "${stats}"
+              printf '%s\n' "$${stats}"
 
               database_dir="/restore/Plug-in Support/Databases"
               sqlite="/usr/lib/plexmediaserver/Plex SQLite"
               for database in \
-                "${database_dir}/com.plexapp.plugins.library.db" \
-                "${database_dir}/com.plexapp.plugins.library.blobs.db"
+                "$${database_dir}/com.plexapp.plugins.library.db" \
+                "$${database_dir}/com.plexapp.plugins.library.blobs.db"
               do
-                if [ ! -f "${database}" ]; then
+                if [ ! -f "$${database}" ]; then
                   echo "expected Plex database is missing"
                   exit 1
                 fi
-                if [ "$("${sqlite}" "${database}" "PRAGMA integrity_check;")" != "ok" ]; then
+                if [ "$("$${sqlite}" "$${database}" "PRAGMA integrity_check;")" != "ok" ]; then
                   echo "restored Plex database integrity check failed"
                   exit 1
                 fi


### PR DESCRIPTION
## Summary

- escape shell variables in the temporary Plex validator from Flux post-build substitution
- leave the drill resources and validation logic otherwise unchanged

## Finding

Flux rejected the Plex Kustomization before creating any drill resource because strict substitution treated a shell variable as a missing GitOps variable. Production was unaffected.

## Validation

- rendered through `flux envsubst --strict` with the required GitOps substitution supplied
- shell syntax checked on the post-substitution Job script
- server-side dry run of the post-substitution app bundle
- `git diff --check`