### PR TITLE
fix(kopiur): make plex drill validation portable

### DIFF
--- a/kubernetes/apps/default/plex/app/restore-drill-remote.yaml
+++ b/kubernetes/apps/default/plex/app/restore-drill-remote.yaml
@@ -41,7 +41,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: plex-restore-remote-drill-validate
+  name: plex-restore-remote-drill-validate-v2
 spec:
   activeDeadlineSeconds: 3600
   backoffLimit: 0
@@ -79,12 +79,7 @@ spec:
                       printf "files=%d bytes=%.0f\n", files, bytes
                       printf "owners=1000:100=%d,1032:100=%d\n",
                         owners["1000:100"], owners["1032:100"]
-                      if (
-                        files == 0 ||
-                        owners["1000:100"] == 0 ||
-                        owners["1032:100"] == 0 ||
-                        owners["1000:100"] + owners["1032:100"] != files
-                      ) {
+                      if (files == 0 || owners["1000:100"] == 0 || owners["1032:100"] == 0 || owners["1000:100"] + owners["1032:100"] != files) {
                         exit 1
                       }
                     }


### PR DESCRIPTION
## Summary

- replace the failed disposable Plex validator with a fresh Job
- use an awk condition accepted by the Plex image implementation
- keep the completed Restore and temporary PVC unchanged

## Finding

The remote restore completed successfully. The first validator exited before database access because the image awk rejected a multiline parenthesised condition.

## Validation

- exact metadata-check program passed against synthetic rows inside the running Plex image
- post-Flux-substitution Job script passed shell syntax validation
- server-side dry run of the post-substitution bundle
- `git diff --check`