### PR TITLE
fix(kopiur): preserve plex drill evidence

### DIFF
--- a/kubernetes/apps/default/plex/app/restore-drill-remote.yaml
+++ b/kubernetes/apps/default/plex/app/restore-drill-remote.yaml
@@ -41,7 +41,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: plex-restore-remote-drill-validate-v2
+  name: plex-restore-remote-drill-validate-v3
 spec:
   activeDeadlineSeconds: 3600
   backoffLimit: 0
@@ -67,25 +67,24 @@ spec:
             - |
               set -eu
 
-              stats="$(
-                find /restore \( -type f -o -type l \) -printf '%U:%G %s\n' |
-                  awk '
-                    {
-                      files++
-                      bytes += $2
-                      owners[$1]++
+              find /restore \( -type f -o -type l \) -printf '%U:%G %s\n' |
+                awk '
+                  {
+                    files++
+                    bytes += $2
+                    owners[$1]++
+                  }
+                  END {
+                    printf "files=%d bytes=%.0f\n", files, bytes
+                    printf "owners=1000:100=%d,1032:100=%d\n",
+                      owners["1000:100"], owners["1032:100"]
+                    printf "unexpected_owners=%d\n",
+                      files - owners["1000:100"] - owners["1032:100"]
+                    if (files == 0 || owners["1000:100"] + owners["1032:100"] != files) {
+                      exit 1
                     }
-                    END {
-                      printf "files=%d bytes=%.0f\n", files, bytes
-                      printf "owners=1000:100=%d,1032:100=%d\n",
-                        owners["1000:100"], owners["1032:100"]
-                      if (files == 0 || owners["1000:100"] == 0 || owners["1032:100"] == 0 || owners["1000:100"] + owners["1032:100"] != files) {
-                        exit 1
-                      }
-                    }
-                  '
-              )"
-              printf '%s\n' "$${stats}"
+                  }
+                '
 
               database_dir="/restore/Plug-in Support/Databases"
               sqlite="/usr/lib/plexmediaserver/Plex SQLite"


### PR DESCRIPTION
## Summary

- replace the failed disposable Plex validator with a fresh Job
- stream restored metadata directly to logs before enforcing ownership
- accept either compatible historical owner class while rejecting all others
- keep the completed Restore and temporary PVC unchanged

## Finding

The v2 validator stopped at an over-strict ownership gate before database access, and command substitution suppressed its metadata output. Production remains unaffected.

## Validation

- compatible-owner gate passed against synthetic restored ownership inside the running Plex image
- post-Flux-substitution Job script passed shell syntax validation
- server-side dry run of the post-substitution bundle
- `git diff --check`