### PR TITLE
refactor(storage): cut over pvc population to kopiur

### DIFF
--- a/docs/guides/repo-guide.md
+++ b/docs/guides/repo-guide.md
@@ -184,6 +184,14 @@ Flux and Kubernetes rendering:
 mise exec -- flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets
 ```
 
+In this repository, the rendered `FluxInstance` pins its sync source to the
+remote `main` branch. Flate follows that source when resolving child
+Kustomization content, so a successful local run proves the committed baseline
+is renderable but can miss branch-only changes beneath those child paths.
+Do not cite it as branch-diff evidence without first proving the changed objects
+appear in its output. Use the Konflate pull-request render, or an explicitly
+branch-aware disposable render, as the authority for those changes.
+
 Image diff for Kubernetes app changes:
 
 ```sh

--- a/docs/operations/storage-and-backups.md
+++ b/docs/operations/storage-and-backups.md
@@ -164,11 +164,12 @@ The root `kopiur` component composes the local and remote snapshot concerns
 with `kopiur/restore`. The restore concern declares a passive
 `Restore` using `source.fromPolicy`, `target.populator: {}`, and
 `onMissingSnapshot: Fail`, plus the application PVC whose `dataSourceRef`
-consumes that Restore. The Restore selects offset 0, pins that snapshot for the
-life of the Restore object, and is recreated without status during a clean
-cluster bootstrap so it selects the repository's latest matching snapshot
-again. Fail-closed population is deliberate: a missing or mismatched snapshot
-must block the protected app rather than silently create blank state.
+consumes that Restore. When population starts, the mover resolves offset 0
+against the repository and does not re-resolve during that Restore. Recreating
+the Restore without status during a clean cluster bootstrap selects the
+repository's latest matching snapshot again. Fail-closed population is
+deliberate: a missing or mismatched snapshot must block the protected app
+rather than silently create blank state.
 
 The app files remain stable during cutover and rollback: every protected app
 includes one root `kopiur` line and one root `volsync` line. Only the two root
@@ -381,15 +382,27 @@ App cutover should not proceed until a Kopiur snapshot for that app has
 succeeded with non-zero file content. The expected cutover shape is:
 
 1. Confirm the recorded TheLounge/Garage and Plex/R2 restore gates remain
-   applicable; rerun only if the restore shape materially changes.
+   applicable, every remote cache resize has converged, and a later remote
+   backup succeeded; rerun a drill only if the restore shape materially
+   changes.
 2. Prepare and render the fleet component switch, proving no target PVC
    capacity shrinks.
-3. In an explicitly approved window, stop the workloads and delete the old app
-   PVCs deliberately.
-4. Let Flux recreate each PVC with the Kopiur `Restore` data source.
-5. Confirm every Restore and PVC, validate application data, and start the
+3. In an explicitly approved window, stop the workloads and verify that no pod
+   mounts a target application PVC.
+4. Merge the component switch. Until the old PVCs are deleted, expect the 19
+   app Kustomizations to report apply failures for immutable `dataSourceRef`
+   changes; pruning the old ReplicationDestinations may wait for the first
+   successful apply. Treat this bounded state as expected during the window,
+   not as permission to start workloads.
+5. Delete exactly the 19 old application PVCs deliberately, then let Flux
+   recreate each PVC with the Kopiur `Restore` data source.
+6. If a Restore mover exhausts its retries, keep that workload stopped, fix the
+   cause, and delete the terminal Restore so Flux recreates it. Use the
+   per-application declarative VolSync rollback instead if recovery is not
+   prompt or trustworthy.
+7. Confirm every Restore and PVC, validate application data, and start the
    workloads.
-6. Confirm a later incremental snapshot, then run the complete
+8. Confirm a later incremental snapshot, then run the complete
    teardown/bootstrap acceptance test before removing VolSync.
 
 After the fleet cutover, update the custom `home-ops-cockpit` Grafana

--- a/docs/operations/storage-and-backups.md
+++ b/docs/operations/storage-and-backups.md
@@ -8,19 +8,23 @@ changes, after restore drills, or when the migration criteria change.
 
 Persistent application data primarily lives on Rook-Ceph `ceph-block` PVCs.
 Selected media-adjacent workloads also mount Synology NAS storage over NFS at
-runtime. VolSync currently protects app PVCs with Restic.
+runtime. Kopiur supplies the passive Restore population path for protected
+application PVCs. VolSync continues to protect them with Restic backups during
+the rollback window.
 
-All 19 protected application PVCs additionally have hourly Kopiur snapshots to
-the local Garage S3 repository and daily snapshots to the independent R2
-repository. VolSync remains enabled and retains the existing PVC and restore
-wiring until the separately approved fleet cutover.
+All 19 protected application PVCs have hourly Kopiur snapshots to the local
+Garage S3 repository and daily snapshots to the independent R2 repository.
+VolSync remains enabled for local and remote backups until the clean-cluster
+rebuild and application verification pass.
 
-The shared VolSync component creates three things for each participating app:
+The shared VolSync component creates two things for each participating app:
 
 - A local Restic `ReplicationSource` scheduled hourly.
-- A local Restic `ReplicationDestination` used by restore workflows.
 - A remote Restic `ReplicationSource` scheduled daily against the R2 secret
   template.
+
+The VolSync local and remote restore helpers remain in Git for rollback and
+disaster recovery, but they are not composed into the live cutover state.
 
 The independent remote target is intentional. The rollout preserves both a
 local target for fast restores and a remote object-storage target for disaster
@@ -37,10 +41,10 @@ restores, keep three identities separate:
 - the NAS/export identity: the UID/GID or server-side mapping used by NFS paths
   when the app or backup repository touches Synology storage.
 
-The current default for VolSync-backed apps is `1032:100` for both the app pod
-and the VolSync Restic movers. This matches the NAS-side `docker` convention and
-keeps most single-app PVC backup and restore paths unprivileged in principle.
-It is this cluster's convention, not a Kopiur requirement.
+The current default for protected apps is `1032:100` for the app pod, Kopiur
+movers, and VolSync Restic movers. This matches the NAS-side `docker` convention
+and keeps most single-app PVC backup and restore paths unprivileged in
+principle. It is this cluster's convention, not a Kopiur requirement.
 
 The `default` namespace currently allows VolSync privileged movers. Treat that
 as a compatibility escape hatch, not the normal permission model. For a
@@ -74,27 +78,27 @@ produces the desired ownership naturally.
 This inventory is derived from the currently included resources in
 `kubernetes/apps/default/kustomization.yaml`.
 
-| App           | VolSync local | VolSync remote | Runtime NAS | Zeroscaler | Notes                                                         |
-| ------------- | ------------- | -------------- | ----------- | ---------- | ------------------------------------------------------------- |
-| `agregarr`    | yes           | yes            | no          | no         | Default VolSync capacity.                                     |
-| `atuin`       | yes           | yes            | no          | no         | Default VolSync capacity.                                     |
-| `autobrr`     | yes           | yes            | no          | no         | Default VolSync capacity.                                     |
-| `bazarr`      | yes           | yes            | yes         | yes        | Kopiur local + remote acceptance; VolSync remains enabled.    |
-| `brrpolice`   | yes           | yes            | no          | no         | Default VolSync capacity.                                     |
-| `maintainerr` | yes           | yes            | no          | no         | Default VolSync capacity.                                     |
-| `plex`        | yes           | yes            | yes         | yes        | Custom VolSync capacity and cache; separate `plex-cache` PVC. |
-| `prowlarr`    | yes           | yes            | no          | no         | Default VolSync capacity.                                     |
-| `qbittorrent` | yes           | yes            | yes         | yes        | NAS availability controls app scale.                          |
-| `qui`         | yes           | yes            | yes         | yes        | NAS availability controls app scale.                          |
-| `radarr`      | yes           | yes            | yes         | yes        | Separate `radarr-cache` PVC.                                  |
-| `radarr-se`   | yes           | yes            | yes         | yes        | Separate `radarr-se-cache` PVC.                               |
-| `recyclarr`   | yes           | yes            | no          | no         | CronJob workload; default VolSync capacity.                   |
-| `resolute`    | yes           | yes            | no          | no         | Default VolSync capacity; single-writer SQLite API.           |
-| `sabnzbd`     | yes           | yes            | yes         | yes        | NAS availability controls app scale.                          |
-| `seerr`       | yes           | yes            | no          | no         | Separate `seerr-cache` PVC.                                   |
-| `sonarr`      | yes           | yes            | yes         | yes        | Separate `sonarr-cache` PVC.                                  |
-| `tautulli`    | yes           | yes            | no          | no         | Separate `tautulli-cache` PVC.                                |
-| `thelounge`   | yes           | yes            | no          | no         | Check SQLite message history before Kopiur.                   |
+| App           | VolSync local | VolSync remote | Runtime NAS | Zeroscaler | Notes                                                      |
+| ------------- | ------------- | -------------- | ----------- | ---------- | ---------------------------------------------------------- |
+| `agregarr`    | yes           | yes            | no          | no         | Default application capacity.                              |
+| `atuin`       | yes           | yes            | no          | no         | Default application capacity.                              |
+| `autobrr`     | yes           | yes            | no          | no         | Default application capacity.                              |
+| `bazarr`      | yes           | yes            | yes         | yes        | Kopiur local + remote acceptance; VolSync remains enabled. |
+| `brrpolice`   | yes           | yes            | no          | no         | Default application capacity.                              |
+| `maintainerr` | yes           | yes            | no          | no         | Default application capacity.                              |
+| `plex`        | yes           | yes            | yes         | yes        | 50Gi app; separate runtime and VolSync caches.             |
+| `prowlarr`    | yes           | yes            | no          | no         | Default application capacity.                              |
+| `qbittorrent` | yes           | yes            | yes         | yes        | NAS availability controls app scale.                       |
+| `qui`         | yes           | yes            | yes         | yes        | NAS availability controls app scale.                       |
+| `radarr`      | yes           | yes            | yes         | yes        | Separate `radarr-cache` PVC.                               |
+| `radarr-se`   | yes           | yes            | yes         | yes        | Separate `radarr-se-cache` PVC.                            |
+| `recyclarr`   | yes           | yes            | no          | no         | CronJob workload; default application capacity.            |
+| `resolute`    | yes           | yes            | no          | no         | Default application capacity; single-writer SQLite API.    |
+| `sabnzbd`     | yes           | yes            | yes         | yes        | NAS availability controls app scale.                       |
+| `seerr`       | yes           | yes            | no          | no         | Separate `seerr-cache` PVC.                                |
+| `sonarr`      | yes           | yes            | yes         | yes        | Separate `sonarr-cache` PVC.                               |
+| `tautulli`    | yes           | yes            | no          | no         | Separate `tautulli-cache` PVC.                             |
+| `thelounge`   | yes           | yes            | no          | no         | Local restore drill passed.                                |
 
 Zeroscaler protects apps that need NAS access at runtime. It does not protect a
 backup mover job by itself. Kopiur's production local path deliberately uses
@@ -120,8 +124,8 @@ explicitly worth preserving.
 
 ## PVC Lifecycle Policy
 
-VolSync-backed app PVCs are managed by the same Flux Kustomization as their app.
-They are therefore prunable when an app is deliberately removed, and that is the
+Protected app PVCs are managed by the same Flux Kustomization as their app. They
+are therefore prunable when an app is deliberately removed, and that is the
 current cleanup policy. Do not add blanket PVC prune-disable annotations without
 a specific migration reason.
 
@@ -156,8 +160,8 @@ independently selectable concerns:
   `volsync/restore` to point that same restore wiring at the existing remote
   Restic repository.
 
-The root `kopiur` component currently composes the local and remote snapshot
-concerns. The prepared `kopiur/restore` concern instead declares a passive
+The root `kopiur` component composes the local and remote snapshot concerns
+with `kopiur/restore`. The restore concern declares a passive
 `Restore` using `source.fromPolicy`, `target.populator: {}`, and
 `onMissingSnapshot: Fail`, plus the application PVC whose `dataSourceRef`
 consumes that Restore. The Restore selects offset 0, pins that snapshot for the
@@ -172,8 +176,8 @@ components change:
 
 | State                  | Kopiur root                    | VolSync root                            |
 | ---------------------- | ------------------------------ | --------------------------------------- |
-| Current                | `local` + `remote`             | `backup` + `restore`                    |
-| Kopiur cutover         | `local` + `remote` + `restore` | `backup`                                |
+| Pre-cutover            | `local` + `remote`             | `backup` + `restore`                    |
+| Current Kopiur cutover | `local` + `remote` + `restore` | `backup`                                |
 | VolSync local rollback | `local` + `remote`             | `backup` + `restore`                    |
 | VolSync remote DR      | `local` + `remote`             | `backup` + `restore` + `restore/remote` |
 
@@ -246,9 +250,10 @@ observable from the cluster.
 
 ## Migration Decision
 
-VolSync Restic remains the working backup and restore system. Kopiur is deployed
-for Bazarr production acceptance alongside it; do not migrate to VolSync-Kopia
-as an intermediate step.
+Kopiur owns backup and passive Restore population for the protected application
+fleet. VolSync Restic continues running in parallel as the rollback backup and
+retained restore path until the clean-cluster rebuild passes; do not migrate to
+VolSync-Kopia as an intermediate step.
 
 The selected rollout is:
 
@@ -278,10 +283,10 @@ The selected rollout is:
 8. Remove VolSync only after the rebuilt applications and their data pass
    verification.
 
-Kopiur enablement adds `SnapshotPolicy` and `SnapshotSchedule` resources only;
-it does not replace existing PVCs or restore wiring. A bound PVC's
-`dataSourceRef` is immutable, so any later VolSync retirement remains a
-deliberate per-app cutover rather than an in-place mutation.
+The cutover cannot mutate a bound PVC's `dataSourceRef`. It therefore requires
+stopping each workload and deliberately deleting and recreating its PVC from
+the Kopiur Restore. VolSync retirement remains separate and happens only after
+the clean-cluster rebuild and application verification pass.
 
 ### Why Not VolSync-Kopia
 

--- a/docs/operations/storage-and-backups.md
+++ b/docs/operations/storage-and-backups.md
@@ -17,14 +17,16 @@ Garage S3 repository and daily snapshots to the independent R2 repository.
 VolSync remains enabled for local and remote backups until the clean-cluster
 rebuild and application verification pass.
 
-The shared VolSync component creates two things for each participating app:
+During the rollback window, `volsync/backup` keeps two Restic backup paths and
+their credential templates for each protected app:
 
 - A local Restic `ReplicationSource` scheduled hourly.
 - A remote Restic `ReplicationSource` scheduled daily against the R2 secret
   template.
 
-The VolSync local and remote restore helpers remain in Git for rollback and
-disaster recovery, but they are not composed into the live cutover state.
+The VolSync local restore component and remote override remain in Git for
+rollback and disaster recovery, but they are not composed into the live
+cutover state.
 
 The independent remote target is intentional. The rollout preserves both a
 local target for fast restores and a remote object-storage target for disaster
@@ -58,10 +60,11 @@ the NAS expects, or use a deliberate shared group/server-side remap. If a future
 Kopia repository uses NFS, repository write permissions are a separate problem
 from source PVC read permissions.
 
-Before migrating any app to Kopiur, verify the actual numeric ownership and file
-modes on the PVC. Kopiur movers are separate pods too; every app needs an
-explicit mover identity decision before trusting a snapshot. For apps already
-aligned to `1032:100`, that can be inheritance or an explicit matching context.
+Before adding an app to this protected set or changing its mover identity,
+verify the actual numeric ownership and file modes on the PVC. Kopiur movers
+are separate pods too; every app needs an explicit mover identity decision
+before trusting a snapshot. For apps already aligned to `1032:100`, that can be
+inheritance or an explicit matching context.
 
 Historical `1000:1000` app exceptions should not be reintroduced as manifest-only
 changes. If an app's runtime identity changes, migrate the PVC ownership in the
@@ -70,35 +73,38 @@ same maintenance window and prove the app can read and write its data afterward.
 Plex retains historical `1000:100` entries alongside newer `1032:100` entries.
 The legacy entries are group-writable, Plex runs as `1032:100`, and the remote
 restore drill normalised the restored application PVC to `1032:100`. Do not
-churn the source PVC with a pre-cutover ownership rewrite; the Kopiur restore
-produces the desired ownership naturally.
+churn the source PVC solely to normalise those historical entries; a Kopiur
+restore produces the desired ownership naturally.
 
-## Backup Inventory
+## Protected Application Inventory
 
 This inventory is derived from the currently included resources in
-`kubernetes/apps/default/kustomization.yaml`.
+`kubernetes/apps/default/kustomization.yaml`. Every row has local and remote
+Kopiur protection plus local and remote VolSync protection during the rollback
+window, so the table records only the properties that vary by app. Separately
+declared cache PVCs are runtime-only and are not backup sources.
 
-| App           | VolSync local | VolSync remote | Runtime NAS | Zeroscaler | Notes                                                      |
-| ------------- | ------------- | -------------- | ----------- | ---------- | ---------------------------------------------------------- |
-| `agregarr`    | yes           | yes            | no          | no         | Default application capacity.                              |
-| `atuin`       | yes           | yes            | no          | no         | Default application capacity.                              |
-| `autobrr`     | yes           | yes            | no          | no         | Default application capacity.                              |
-| `bazarr`      | yes           | yes            | yes         | yes        | Kopiur local + remote acceptance; VolSync remains enabled. |
-| `brrpolice`   | yes           | yes            | no          | no         | Default application capacity.                              |
-| `maintainerr` | yes           | yes            | no          | no         | Default application capacity.                              |
-| `plex`        | yes           | yes            | yes         | yes        | 50Gi app; separate runtime and VolSync caches.             |
-| `prowlarr`    | yes           | yes            | no          | no         | Default application capacity.                              |
-| `qbittorrent` | yes           | yes            | yes         | yes        | NAS availability controls app scale.                       |
-| `qui`         | yes           | yes            | yes         | yes        | NAS availability controls app scale.                       |
-| `radarr`      | yes           | yes            | yes         | yes        | Separate `radarr-cache` PVC.                               |
-| `radarr-se`   | yes           | yes            | yes         | yes        | Separate `radarr-se-cache` PVC.                            |
-| `recyclarr`   | yes           | yes            | no          | no         | CronJob workload; default application capacity.            |
-| `resolute`    | yes           | yes            | no          | no         | Default application capacity; single-writer SQLite API.    |
-| `sabnzbd`     | yes           | yes            | yes         | yes        | NAS availability controls app scale.                       |
-| `seerr`       | yes           | yes            | no          | no         | Separate `seerr-cache` PVC.                                |
-| `sonarr`      | yes           | yes            | yes         | yes        | Separate `sonarr-cache` PVC.                               |
-| `tautulli`    | yes           | yes            | no          | no         | Separate `tautulli-cache` PVC.                             |
-| `thelounge`   | yes           | yes            | no          | no         | Local restore drill passed.                                |
+| App           | App PVC | Runtime NAS | Zeroscaler | Other state or constraint          |
+| ------------- | ------- | ----------- | ---------- | ---------------------------------- |
+| `agregarr`    | 5Gi     | no          | no         | —                                  |
+| `atuin`       | 5Gi     | no          | no         | —                                  |
+| `autobrr`     | 5Gi     | no          | no         | —                                  |
+| `bazarr`      | 5Gi     | yes         | yes        | —                                  |
+| `brrpolice`   | 5Gi     | no          | no         | —                                  |
+| `maintainerr` | 5Gi     | no          | no         | —                                  |
+| `plex`        | 50Gi    | yes         | yes        | `plex-cache` 75Gi runtime PVC      |
+| `prowlarr`    | 5Gi     | no          | no         | —                                  |
+| `qbittorrent` | 5Gi     | yes         | yes        | —                                  |
+| `qui`         | 5Gi     | yes         | yes        | —                                  |
+| `radarr`      | 5Gi     | yes         | yes        | `radarr-cache` 10Gi runtime PVC    |
+| `radarr-se`   | 5Gi     | yes         | yes        | `radarr-se-cache` 10Gi runtime PVC |
+| `recyclarr`   | 5Gi     | no          | no         | CronJob                            |
+| `resolute`    | 5Gi     | no          | no         | Single-writer SQLite API           |
+| `sabnzbd`     | 5Gi     | yes         | yes        | —                                  |
+| `seerr`       | 5Gi     | no          | no         | `seerr-cache` 15Gi runtime PVC     |
+| `sonarr`      | 5Gi     | yes         | yes        | `sonarr-cache` 10Gi runtime PVC    |
+| `tautulli`    | 5Gi     | no          | no         | `tautulli-cache` 15Gi runtime PVC  |
+| `thelounge`   | 5Gi     | no          | no         | —                                  |
 
 Zeroscaler protects apps that need NAS access at runtime. It does not protect a
 backup mover job by itself. Kopiur's production local path deliberately uses
@@ -112,10 +118,11 @@ availability posture and handle non-Deployment workloads separately.
 
 ## Intentional Non-Coverage
 
-The inventory above is scoped to the `default` namespace application PVCs.
-Observability PVCs such as Prometheus, Alertmanager, Grafana, Gatus sidecar, and
-Victoria Logs are intentionally not VolSync-backed. Losing them loses telemetry
-history or non-declarative UI changes, not the Git source of truth.
+The inventory above is scoped to the protected `default` namespace application
+PVCs. Observability PVCs such as Prometheus, Alertmanager, Grafana, Gatus
+sidecar, and Victoria Logs are intentionally outside that backup set. Losing
+them loses telemetry history or non-declarative UI changes, not the Git source
+of truth.
 
 Hermes and the AI workbench are intentionally lightweight and stateless. The
 Hermes home directory currently lives on `emptyDir`; do not add persistence or
@@ -182,7 +189,7 @@ components change:
 | VolSync local rollback | `local` + `remote`             | `backup` + `restore`                    |
 | VolSync remote DR      | `local` + `remote`             | `backup` + `restore` + `restore/remote` |
 
-The VolSync restore helper and remote override remain in Git, and both
+The VolSync local restore component and remote override remain in Git, and both
 repository credentials remain supplied by `volsync/backup` throughout the
 cutover. The remote override gives the destination a distinct
 `${APP}-r2-dst` name as well as changing its repository, so an existing
@@ -312,11 +319,11 @@ Kopiur is not yet the sole backup system. Local evidence now includes both
 production backends, maintenance, and restore tests; peer testing remains
 useful supporting evidence rather than a substitute for those local results.
 
-## Bazarr Production Acceptance
+## Kopiur Production Acceptance
 
 Track the rollout in
 [Adopt Kopiur (#1487)](https://github.com/alex-matthews/home-ops/issues/1487).
-Bazarr is the first production-acceptance app because it has meaningful
+Bazarr was the first production-acceptance app because it has meaningful
 configuration and database state while remaining reconstructable.
 
 The production shape follows
@@ -326,8 +333,8 @@ The production shape follows
   not pass through the NFS daemon.
 - The remote repository is independent R2 with its own encryption password,
   schedule, retention, and maintenance. `RepositoryReplication` is not used.
-- VolSync remains enabled and continues to own the existing PVC and restore
-  wiring.
+- During Bazarr acceptance, VolSync remained enabled and continued to own its
+  PVC and restore wiring.
 
 Both production restore paths have been proven through temporary GitOps
 resources. Garage and R2 each restored the latest Bazarr snapshot into an
@@ -465,15 +472,14 @@ Useful read-only checks:
 
 ```sh
 kubectl get replicationsource,replicationdestination -A
-kubectl get clusterrepository,snapshotpolicy,snapshotschedule,snapshot -A
+kubectl get clusterrepository,snapshotpolicy,snapshotschedule,snapshot,restores.kopiur.home-operations.com -A
 kubectl -n kopiur-system get maintenance,job
 kubectl get persistentvolumeclaim -A
 kubectl -n default get hpa
 kubectl -n observability get probe nfs -o yaml
-kubectl -n default get replicationdestination -o jsonpath='{range .items[*]}{.metadata.name}{" cap="}{.spec.restic.capacity}{" cache="}{.spec.restic.cacheCapacity}{" repo="}{.spec.restic.repository}{" ssa="}{.metadata.labels.kustomize\.toolkit\.fluxcd\.io/ssa}{"\n"}{end}'
 ```
 
-Current Restic inspection and pre-cutover in-place restore helpers:
+Current Restic inspection and guarded in-place restore helpers:
 
 ```sh
 just volsync list-previous default <app>

--- a/docs/operations/storage-and-backups.md
+++ b/docs/operations/storage-and-backups.md
@@ -460,12 +460,22 @@ kubectl -n observability get probe nfs -o yaml
 kubectl -n default get replicationdestination -o jsonpath='{range .items[*]}{.metadata.name}{" cap="}{.spec.restic.capacity}{" cache="}{.spec.restic.cacheCapacity}{" repo="}{.spec.restic.repository}{" ssa="}{.metadata.labels.kustomize\.toolkit\.fluxcd\.io/ssa}{"\n"}{end}'
 ```
 
-Current Restic snapshot and restore helpers:
+Current Restic inspection and pre-cutover in-place restore helpers:
 
 ```sh
 just volsync list-previous default <app>
-just volsync restore default <app> 0
+just volsync list-previous default <app> remote
+just volsync restore-in-place default <app> 0
+just volsync restore-in-place default <app> 0 remote
 ```
+
+`restore-in-place` is destructive: it stops a Deployment or StatefulSet and
+overwrites its existing PVC directly. It refuses PVCs that were not populated
+by a VolSync `ReplicationDestination`, including post-cutover Kopiur PVCs. It
+is not the fleet cutover or normal rollback path. For rollback after cutover,
+recompose the retained `volsync/restore` component (and its `remote` override
+only for remote DR), then deliberately recreate the affected PVC as described
+above.
 
 Render checks for future manifest changes:
 

--- a/docs/operations/storage-and-backups.md
+++ b/docs/operations/storage-and-backups.md
@@ -412,6 +412,11 @@ succeeded with non-zero file content. The expected cutover shape is:
 8. Confirm a later incremental snapshot, then run the complete
    teardown/bootstrap acceptance test before removing VolSync.
 
+Tuppr deliberately blocks Talos and Kubernetes upgrades while any Kopiur
+Restore is `Resolving` or `Restoring`. Expect that guardrail to hold throughout
+PVC population; do not override it or interpret the blocked upgrade as a
+cutover failure.
+
 After the fleet cutover, update the custom `home-ops-cockpit` Grafana
 dashboard. Its Backups stat, dashboard link, and backup branch in Attention
 detail currently use only VolSync metrics. During the rollback overlap, add

--- a/docs/operations/storage-and-backups.md
+++ b/docs/operations/storage-and-backups.md
@@ -394,22 +394,32 @@ succeeded with non-zero file content. The expected cutover shape is:
    changes.
 2. Prepare and render the fleet component switch, proving no target PVC
    capacity shrinks.
-3. In an explicitly approved window, stop the workloads and verify that no pod
-   mounts a target application PVC.
-4. Merge the component switch. Until the old PVCs are deleted, expect the 19
+3. In an explicitly approved window, suspend the 19 application
+   Kustomizations and HelmReleases, suspend the Recyclarr CronJob, and set the
+   eight zeroscaler HPAs' `scaleUp.selectPolicy` to `Disabled`. The cutover
+   commit carries the same HPA hold so it survives reconciliation. Stop the
+   workloads and verify that no pod mounts a target application PVC.
+4. With the application PVCs quiescent, complete and verify a final local and
+   remote VolSync cycle and one manual local Kopiur Snapshot per app. These are
+   the exact rollback and restore points for the window; do not continue from
+   an older running-workload snapshot.
+5. Merge the component switch. Until the old PVCs are deleted, expect the 19
    app Kustomizations to report apply failures for immutable `dataSourceRef`
    changes; pruning the old ReplicationDestinations may wait for the first
    successful apply. Treat this bounded state as expected during the window,
    not as permission to start workloads.
-5. Delete exactly the 19 old application PVCs deliberately, then let Flux
-   recreate each PVC with the Kopiur `Restore` data source.
-6. If a Restore mover exhausts its retries, keep that workload stopped, fix the
+6. Resume the application Kustomizations, verify the HelmRelease and HPA holds
+   remain in place, and delete exactly the 19 old application PVCs
+   deliberately. Let Flux recreate each PVC with the Kopiur `Restore` data
+   source.
+7. If a Restore mover exhausts its retries, keep that workload stopped, fix the
    cause, and delete the terminal Restore so Flux recreates it. Use the
    per-application declarative VolSync rollback instead if recovery is not
    prompt or trustworthy.
-7. Confirm every Restore and PVC, validate application data, and start the
-   workloads.
-8. Confirm a later incremental snapshot, then run the complete
+8. Confirm every Restore and PVC and validate application data. Restore the
+   zeroscaler `scaleUp.selectPolicy: Max` setting, resume the HelmReleases and
+   Recyclarr schedule, and start the workloads.
+9. Confirm a later incremental snapshot, then run the complete
    teardown/bootstrap acceptance test before removing VolSync.
 
 Tuppr deliberately blocks Talos and Kubernetes upgrades while any Kopiur

--- a/kubernetes/components/kopiur/kustomization.yaml
+++ b/kubernetes/components/kopiur/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Component
 components:
   - ./local
   - ./remote
+  - ./restore

--- a/kubernetes/components/volsync/kustomization.yaml
+++ b/kubernetes/components/volsync/kustomization.yaml
@@ -4,4 +4,3 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 components:
   - ./backup
-  - ./restore

--- a/kubernetes/components/zeroscaler/horizontalpodautoscaler.yaml
+++ b/kubernetes/components/zeroscaler/horizontalpodautoscaler.yaml
@@ -34,5 +34,6 @@ spec:
         - type: Pods
           value: 1
           periodSeconds: 15
-      selectPolicy: Max
+      # Cutover hold: restore Max after the Kopiur-populated PVCs are verified.
+      selectPolicy: Disabled
       stabilizationWindowSeconds: 0

--- a/volsync/mod.just
+++ b/volsync/mod.just
@@ -4,17 +4,23 @@ set quiet
 set script-interpreter := ['bash', '-euo', 'pipefail']
 set shell := ['bash', '-euo', 'pipefail', '-c']
 
-[doc('List snapshots (and corresponding previous offset integers) in the restic repo for an app')]
-list-previous ns app:
-    kubectl -n "{{ ns }}" get secret "{{ app }}-volsync-secret" -o json \
+[arg('repository', pattern='local|remote')]
+[doc('List snapshots (and corresponding previous offset integers) in a Restic repo for an app')]
+list-previous ns app repository="local":
+    secret="{{ app }}-volsync-secret"
+    if [[ "{{ repository }}" == remote ]]; then
+        secret="{{ app }}-volsync-r2-secret"
+    fi
+    kubectl -n "{{ ns }}" get secret "$secret" -o json \
         | jq -r '.data | to_entries[] | "export \(.key)=\(.value | @base64d | @sh)"' \
         | bash -euo pipefail -c 'source /dev/stdin && restic snapshots --json' \
         | jq -r '[.. | objects | select(has("id") and has("time")) | {id: (.short_id // .id[0:8]), time: (.time | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601 | strflocaltime("%Y-%m-%d %H:%M:%S")), host: (.hostname // ""), tags: ((.tags // []) | join(",")), paths: ((.paths // []) | join(",")), bytes: (.summary.total_bytes_processed // 0)}] | unique_by(.id) | sort_by(.time) | reverse | to_entries[] | [(.key | tostring), .value.id, .value.time, .value.host, .value.tags, .value.paths, (.value.bytes | tostring)] | @tsv' \
         | awk -F $'\t' 'function humansize(n, mib, gib, tib){mib=1024*1024; gib=mib*1024; tib=gib*1024; if(n>=tib)return sprintf("%.3f TiB",n/tib); if(n>=gib)return sprintf("%.3f GiB",n/gib); if(n>=mib)return sprintf("%.3f MiB",n/mib); if(n>=1024)return sprintf("%.3f KiB",n/1024); return sprintf("%d B",n)} BEGIN{printf "%-4s  %-8s  %-19s  %-10s  %-10s  %-5s  %s\n","Prev","ID","Time","Host","Tags","Paths","Size"; print "--------------------------------------------------------------------------------"} {printf "%-4s  %-8s  %-19s  %-10s  %-10s  %-5s  %s\n",$1,$2,$3,$4,$5,$6,humansize($7+0)} END{print "--------------------------------------------------------------------------------"}'
 
-[doc('Restore an app from a snapshot based on previous offset integer (0=latest)')]
-restore ns app previous:
-    just volsync restore-run "{{ ns }}" "{{ app }}" "{{ previous }}"
+[arg('repository', pattern='local|remote')]
+[doc('DESTRUCTIVE: Restore a VolSync-populated PVC in place from a Restic snapshot')]
+restore-in-place ns app previous repository="local":
+    just volsync restore-in-place-run "{{ ns }}" "{{ app }}" "{{ previous }}" "{{ repository }}"
 
 [doc('Resume VolSync')]
 resume:
@@ -68,21 +74,36 @@ autoscaler-resume ns app:
     flux -n "{{ ns }}" reconcile kustomization "{{ app }}" --with-source
 
 [private]
-restore-run ns app previous:
+restore-in-place-run ns app previous repository:
     [[ "{{ previous }}" =~ ^[0-9]+$ ]] || {
         echo "previous must be an integer offset (0=latest, 1=one snapshot back)" >&2
         exit 1
     }
+    source="{{ app }}"
+    repository_secret="{{ app }}-volsync-secret"
+    if [[ "{{ repository }}" == remote ]]; then
+        source="{{ app }}-r2"
+        repository_secret="{{ app }}-volsync-r2-secret"
+    fi
+    rs="replicationsources/$source"
+    claim="$(kubectl -n "{{ ns }}" get "$rs" -o jsonpath='{.spec.sourcePVC}')"
+    controller="$(just volsync detect-controller "{{ ns }}" "{{ app }}")"
+    data_source_group="$(kubectl -n "{{ ns }}" get pvc "$claim" \
+        -o jsonpath='{.spec.dataSourceRef.apiGroup}')"
+    data_source_kind="$(kubectl -n "{{ ns }}" get pvc "$claim" \
+        -o jsonpath='{.spec.dataSourceRef.kind}')"
+    if [[ "$data_source_group" != volsync.backube \
+        || "$data_source_kind" != ReplicationDestination ]]; then
+        echo "Refusing restore-in-place: {{ ns }}/$claim is not populated by a VolSync ReplicationDestination" >&2
+        echo "Use the Git-managed VolSync rollback component and recreate the PVC instead" >&2
+        exit 2
+    fi
     flux -n "{{ ns }}" suspend kustomization "{{ app }}"
     flux -n "{{ ns }}" suspend helmrelease "{{ app }}"
     just volsync autoscaler-suspend "{{ ns }}" "{{ app }}" || true
-    kubectl -n "{{ ns }}" scale \
-        "$(just volsync detect-controller "{{ ns }}" "{{ app }}")/{{ app }}" \
-        --replicas=0
+    kubectl -n "{{ ns }}" scale "$controller/{{ app }}" --replicas=0
     kubectl -n "{{ ns }}" wait pod --for=delete \
         --selector="app.kubernetes.io/name={{ app }}" --timeout=5m || true
-    rs="replicationsources/{{ app }}"
-    claim="$(kubectl -n "{{ ns }}" get "$rs" -o jsonpath='{.spec.sourcePVC}')"
     access_modes="$(kubectl -n "{{ ns }}" get "$rs" -o jsonpath='{.spec.restic.accessModes}')"
     storage_class_name="$(kubectl -n "{{ ns }}" get "$rs" \
         -o jsonpath='{.spec.restic.storageClassName}')"
@@ -98,6 +119,7 @@ restore-run ns app previous:
         STORAGE_CLASS_NAME="$storage_class_name" \
         PUID="$puid" \
         PGID="$pgid" \
+        REPOSITORY="$repository_secret" \
             just template "{{ source_directory() }}/replicationdestination.yaml.j2" \
             | kubectl apply --server-side -f -
     until kubectl -n "{{ ns }}" get job/volsync-dst-{{ app }}-manual &>/dev/null; do sleep 5; done

--- a/volsync/replicationdestination.yaml.j2
+++ b/volsync/replicationdestination.yaml.j2
@@ -8,7 +8,7 @@ spec:
   trigger:
     manual: restore-once
   restic:
-    repository: {{ ENV.APP }}-volsync-secret
+    repository: {{ ENV.REPOSITORY }}
     destinationPVC: {{ ENV.CLAIM }}
     copyMethod: Direct
     storageClassName: {{ ENV.STORAGE_CLASS_NAME }}


### PR DESCRIPTION
## Summary

- Compose the passive Kopiur restore/PVC concern from the central Kopiur component.
- Keep only the local and remote VolSync backup concerns in the live VolSync component.
- Retain the VolSync local and remote restore helpers in Git for rollback and disaster recovery.
- Make the legacy direct-restore recipe explicitly destructive, local/remote-selectable, and guarded against Kopiur-populated PVCs.
- Update the storage runbook to describe the cutover and retained recovery paths.

Merging this PR does not authorise the live maintenance actions below.

## Rendered impact

- 19 application PVCs change only their `dataSourceRef`, from a VolSync `ReplicationDestination` to the corresponding Kopiur `Restore`.
- 19 passive Kopiur `Restore` resources are added.
- 19 live VolSync `ReplicationDestination` resources are removed from the desired state.
- PVC capacity remains unchanged: 18 at 5Gi and Plex at 50Gi.
- VolSync local and remote `ReplicationSource` backups remain enabled.
- The eight zeroscaler HPAs temporarily disable scale-up so they cannot restart
  applications during PVC population. A one-line follow-up restores `Max`
  before the applications are released.
- No application image, backup schedule, retention, storage class, or
  application-controller manifest changes.

## Operator helpers

- `just volsync list-previous` can inspect either the local or remote Restic repository.
- The ambiguous `just volsync restore` entry becomes `just volsync restore-in-place`.
- `restore-in-place` checks the workload type and PVC population source before suspending anything. It refuses Kopiur-populated PVCs and is not the post-cutover rollback path.
- No bulk workload-stop or PVC-deletion recipe is added; those remain explicit maintenance-window actions.

## Merge blockers

- [ ] Use an explicitly approved maintenance window; do not merge while protected workloads are running.
- [x] Allow all remote mover cache PVC expansions to complete and confirm the next remote backups succeed.
- [ ] Immediately before the window, confirm current local and remote Kopiur snapshots and both VolSync backup paths are healthy.
- [ ] Confirm the exact workload stop/start, verification, rollback, and operator ownership checklist.

## Maintenance outline

1. Suspend the 19 application Kustomizations and HelmReleases, suspend the
   Recyclarr CronJob, and patch the eight live zeroscaler HPAs to
   `scaleUp.selectPolicy: Disabled`.
2. Stop the 18 protected Deployments and verify no pod mounts a target
   application PVC.
3. With the PVCs quiescent, complete and verify a final local and remote
   VolSync cycle and one manual local Kopiur Snapshot per app.
4. Merge this PR, wait for the Git source to observe it, and resume the 19
   application Kustomizations. Verify the HelmRelease and HPA holds remain.
   Until the old PVCs are deleted, expect immutable-field apply failures;
   pruning the old ReplicationDestinations may wait for a successful apply.
5. Deliberately delete exactly the 19 old application PVCs and allow Flux to
   recreate the 19 Kopiur Restore/PVC pairs.
6. If a Restore mover exhausts its retries, keep that workload stopped, fix
   the cause, and delete the terminal Restore so Flux recreates it; use
   per-application declarative rollback if recovery is not prompt or
   trustworthy.
7. Verify Restore and PVC conditions, requested sizes, representative
   files/databases, and application-level checks.
8. Restore the zeroscaler `Max` policy, resume the HelmReleases and Recyclarr
   schedule, and verify all applications before ending the window.

Tuppr is expected to hold Talos and Kubernetes upgrades while any Restore is `Resolving` or `Restoring`. That is the intended health gate during PVC population, not a cutover failure.

The PVC deletions and workload changes are separate live mutations requiring exact approval during the maintenance window.

## Rollback

Revert the central component switch so VolSync restore wiring is composed again. With the affected workload stopped, delete only its Kopiur-populated PVC and allow the retained local VolSync helper to recreate and populate it. Use the retained remote override only if the local copy is unavailable or untrusted.

Rollback replaces the current restored PVC and therefore also requires exact approval during the maintenance window. Kopiur policies/schedules and both VolSync backup sources remain intact throughout the rollback window.

## Validation

- `mise exec --no-deps -- oxfmt --check ...`
- Flate baseline validation — 210 passed. Because the rendered FluxInstance pins child content to remote `main`, this proves baseline health rather than the branch diff.
- Konflate PR-ref render — exactly 19 PVC source changes, 19 Kopiur Restores added, and 19 VolSync ReplicationDestinations removed.
- Refreshed independent branch-aware structural render against current `main`
  — confirmed the same 19/19/19 accounting, retained all 38 VolSync
  ReplicationSources, and found no capacity, storage-class, runtime-cache,
  image-bearing, or unrelated common-resource changes. The only additional
  common-resource changes are the expected eight HPA `Max` → `Disabled`
  scale-up holds.
- Server-side dry run — all 19 Restores were admitted by the live Kopiur 0.8.0 CRD and webhook.
- Server-side dry run — the live Kubernetes API accepted the HPA
  `scaleUp.selectPolicy: Disabled` hold.

Refs #1487
