### PR TITLE
feat(tuppr): gate upgrades on kopiur activity

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -13,6 +13,14 @@ spec:
       kind: ReplicationSource
       expr: |-
         status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
+    - apiVersion: kopiur.home-operations.com/v1alpha1
+      kind: Snapshot
+      expr: |-
+        status.phase != 'Running'
+    - apiVersion: kopiur.home-operations.com/v1alpha1
+      kind: Restore
+      expr: |-
+        !(status.phase in ['Resolving', 'Restoring'])
     - apiVersion: ceph.rook.io/v1
       kind: CephCluster
       expr: |-

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -15,6 +15,14 @@ spec:
       kind: ReplicationSource
       expr: |-
         status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
+    - apiVersion: kopiur.home-operations.com/v1alpha1
+      kind: Snapshot
+      expr: |-
+        status.phase != 'Running'
+    - apiVersion: kopiur.home-operations.com/v1alpha1
+      kind: Restore
+      expr: |-
+        !(status.phase in ['Resolving', 'Restoring'])
     - apiVersion: ceph.rook.io/v1
       kind: CephCluster
       expr: |-


### PR DESCRIPTION
## Summary

- Block Kubernetes and Talos upgrades while a Kopiur snapshot is running.
- Block upgrades while a Kopiur restore is resolving or restoring.
- Retain the existing VolSync and Ceph health checks during backup-system coexistence.

This is separated from the PVC-population cutover so the gates can protect the pending Kubernetes and Talos upgrades.

## Validation

- `mise exec --no-deps -- oxfmt --check kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml`
- `mise exec -- kubectl kustomize kubernetes/apps/system-upgrade/tuppr/upgrades`
- `git diff --check`