### PR TITLE
fix(descheduler): tighten workload balancing

### DIFF
--- a/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
@@ -20,6 +20,7 @@ spec:
           pluginConfig:
             - name: DefaultEvictor
               args:
+                nodeFit: true
                 podProtections:
                   defaultDisabled:
                     - FailedBarePods
@@ -27,16 +28,18 @@ spec:
                     - SystemCriticalPods
             - name: LowNodeUtilization
               args:
+                evictionLimits:
+                  node: 5
                 metricsUtilization:
                   source: KubernetesMetrics
                 thresholds:
                   cpu: 20
                   memory: 20
-                  pods: 20
+                  pods: 35
                 targetThresholds:
                   cpu: 50
                   memory: 50
-                  pods: 50
+                  pods: 45
             - name: RemoveFailedPods
               args:
                 reasons:


### PR DESCRIPTION
## Summary

- narrow the pod-utilisation band from 20–50% to 35–45%
- require an alternative node fit before eviction
- limit LowNodeUtilization to five evictions per source node per cycle
- retain the existing CPU and memory thresholds

## Why

The previous pod thresholds deliberately accepted a wide distribution after rolling maintenance. A narrower pod band converges more closely across the identical worker nodes, while the eviction limit avoids another large burst of simultaneous restarts.

## Validation

- `mise exec -- kubectl kustomize kubernetes/apps/kube-system/descheduler/app`
- `mise exec -- flate test all -p ./kubernetes/flux/cluster --allow-missing-secrets` (210 passed; existing missing-secret offline warning only)
- `mise exec -- flate diff images -p ./kubernetes/flux/cluster -o json` (empty)
- `mise exec --no-deps -- oxfmt --check kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml`

## Rollback

Revert this commit to restore the previous 20–50% pod band, unlimited per-plugin evictions, and the prior node-fit behaviour.