### PR TITLE
fix(zeroscaler): release the cutover autoscaler hold

### DIFF
--- a/kubernetes/components/zeroscaler/horizontalpodautoscaler.yaml
+++ b/kubernetes/components/zeroscaler/horizontalpodautoscaler.yaml
@@ -34,6 +34,5 @@ spec:
         - type: Pods
           value: 1
           periodSeconds: 15
-      # Cutover hold: restore Max after the Kopiur-populated PVCs are verified.
-      selectPolicy: Disabled
+      selectPolicy: Max
       stabilizationWindowSeconds: 0


### PR DESCRIPTION
Step 8 of the Kopiur cutover (#1487): releases the temporary autoscaler hold added by #1623.

**Do not merge until the recreated PVCs, Restores and application data are verified.** Merging this is what allows the eight NAS-dependent apps to scale up again.

## Why this is a PR and not a `kubectl patch`

Flux owns `spec.behavior.scaleUp.selectPolicy` on these HPAs and there is no `ssa: IfNotPresent` override, so a manual patch back to `Max` is reverted at the next reconcile (app Kustomization `interval: 1h`). Scale-up would silently re-disable, leaving the eight apps one `nfs_probe` blip away from scaling to zero with no path back up. The hold was introduced declaratively, so it has to be released declaratively.

## Change

One line, restoring `scaleUp.selectPolicy: Max` and dropping the temporary comment. The resulting file is **byte-identical to the pre-cutover version on `main`** — the hold leaves no residue.

Affects the eight apps composing `components/zeroscaler`: bazarr, plex, qbittorrent, qui, radarr, radarr-se, sabnzbd, sonarr. No other component, workload or backup object changes.

## Validation

- `oxfmt --check` clean
- Rendered through a zeroscaler consumer: `scaleUp.selectPolicy: Max`, policies and `stabilizationWindowSeconds` unchanged
- Diff against pre-cutover `main` for this file: empty

## Before merging

This PR is currently based on the #1623 branch so the diff renders as the single intended line. Because the repo squash-merges, **re-cut it onto `main` after #1623 lands** rather than relying on automatic retargeting:

```
git fetch origin && git checkout -B kopiur-restore-zeroscaler-scaleup origin/main
# reapply the one-line change, commit, push --force-with-lease
```

Then confirm base is `main`, the diff is exactly this one line, and the full check suite runs.

## Expected effect on merge

Flux applies `Max` to the eight HPAs; with `nfs_probe` healthy and `minReplicas: 0`, each scales back to one replica. Verify all eight reach `currentReplicas: 1` and that `nfs_probe` stays clean.

## Rollback

Revert to reinstate the hold.