### PR TITLE
docs(hermes): document MCP session recovery

### DIFF
--- a/docs/operations/ai-workbench.md
+++ b/docs/operations/ai-workbench.md
@@ -156,8 +156,14 @@ same recall surface and the storage/security model is clear.
 If Hermes reports `session terminated (404). need to re-initialize`,
 `method "tools/call" is invalid during session initialization`, or
 `MCP event loop is not running`, treat that as a Hermes MCP session lifecycle
-failure. Reload MCP or restart the Hermes gateway before retrying the same
-single-tool smoke prompt.
+failure. A ToolHive workload replacement invalidates its in-memory Streamable
+HTTP session, but Hermes should detect that on its next keepalive, reconnect,
+and repopulate the MCP tools automatically. Wait one keepalive interval
+(currently 180 seconds), confirm the ToolHive catalog is present on the MCP
+page, then retry the same single-tool smoke prompt. Reload MCP or restart the
+Hermes gateway only if the catalog does not return or the retry still fails
+with a session-lifecycle error. Model-provider failures occur before the MCP
+call and should be diagnosed separately.
 
 If Hermes shows visible `Thinking` blocks, test the response-display setting
 first. Do not reduce `agent.reasoning_effort` just to hide reasoning; that is a


### PR DESCRIPTION
## Summary

- document automatic Hermes reconnect after ToolHive workload replacement
- make MCP reload or gateway restart a fallback rather than the first response
- distinguish model-provider failures from MCP session failures

## Validation

- mise exec --no-deps -- oxfmt --check docs/operations/ai-workbench.md
- git diff --check

Related: #1298