### PR TITLE
fix(rook-ceph): persist manager log OOM workaround

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -37,6 +37,8 @@ spec:
           bdev_async_discard_threads: "1" # quote
           osd_class_update_on_start: "false" # quote
           device_failure_prediction_mode: local # requires mgr module
+        mgr:
+          log_max_recent: "100" # quote
       cleanupPolicy:
         wipeDevicesFromOtherClusters: true
       crashCollector:


### PR DESCRIPTION
## Summary

- persist the manager-scoped `log_max_recent` cap at `100`
- bound Ceph manager in-memory recent logs to mitigate the current OOM behavior
- leave pools, OSDs, PVCs, and storage topology unchanged

## Impact

Rook actively applies this runtime-updatable Ceph configuration. No cluster, pool, or OSD rebuild is expected.

## Validation

- `mise exec -- oxfmt --check kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml`
- `mise exec -- kubectl kustomize kubernetes/apps/rook-ceph/rook-ceph/cluster`
- pinned Rook cluster chart render at `v1.20.3`
- read-only live check confirmed the option is valid and runtime-updatable; cluster health was clean before the change

## Rollback

Set `mgr.log_max_recent` back to `10000` in Git and reconcile. Rook does not unset a `cephConfig` option merely because the key is removed, so deleting the key alone is not a complete rollback.