### PR TITLE
feat(coredns): tune for ipv4-only cluster

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -27,6 +27,19 @@ spec:
             use_tcp: true
         port: 53
         plugins:
+          # The cluster is SingleStack/IPv4, so an AAAA answer is unusable even
+          # when upstream returns one. Answer AAAA locally with NODATA instead
+          # of forwarding it. Plugin order comes from plugin.cfg, not this
+          # list: template(60) runs before kubernetes(67) and forward(73), so
+          # AAAA never leaves the cluster.
+          #
+          # This is a `.`-wide blackhole with no fallthrough and it fails
+          # silently as NODATA, not as an error. Remove it before introducing
+          # IPv6 or reaching any IPv6-only external host.
+          - name: template
+            parameters: ANY AAAA
+            configBlock: |-
+              authority "{{ .Zone }} 60 IN SOA ns.dns.cluster.local. hostmaster.cluster.local. (1 60 60 60 60)"
           - name: errors
           - name: health
             configBlock: |-
@@ -41,10 +54,14 @@ spec:
             parameters: "@kubernetes"
           - name: forward
             parameters: . /etc/resolv.conf
+          # servfail 0: upstream failures here are intermittent and the same
+          # names resolve on retry, so replaying a cached SERVFAIL for 5s only
+          # widens the blast radius.
           - name: cache
             configBlock: |-
               prefetch 20
               serve_stale
+              servfail 0
           - name: loop
           - name: reload
           - name: loadbalance
@@ -53,6 +70,9 @@ spec:
           - name: log
             configBlock: |-
               class error
+    # Cluster DNS should not be evicted ahead of ordinary workloads under node
+    # memory pressure.
+    priorityClassName: system-cluster-critical
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Three changes to the CoreDNS `HelmRelease`, adapted from [onedr0p/home-ops#11428](https://www.github.com/onedr0p/home-ops/pull/11428).

## `template ANY AAAA` — answer AAAA locally with NODATA

The cluster is `SingleStack`/`IPv4`, so an AAAA answer is unusable even when upstream returns one — but `pkg-containers.githubusercontent.com` and `mirror.gcr.io` are dual-stack and did return one. A large Konflate render then failed 18 chart fetches with `dial tcp [2606:50c0:...]:443: connect: network is unreachable`, on exactly those addresses.

Most clients survive this on Happy Eyeballs — `curl` from a pod picked the IPv4 and returned in 0.3s — which is why only the 24-app render broke and small ones always passed. It was concurrency-triggered, not deterministic: 18 failures on the first run, 4 on a re-run of the identical tree, **0 after this change**. Answering AAAA locally removes the unroutable address entirely, and stops every AAAA query walking the full `ndots:5` search path to produce nothing.

Plugin order comes from `plugin.cfg`, not Corefile order. Verified at `v1.14.6`, the image we run:

```
cache(53) → autopath(58) → template(60) → hosts(62) → kubernetes(67) → forward(73)
```

`template` fires before both `kubernetes` and `forward`, so AAAA never leaves the cluster. For `*.svc.cluster.local` the result is identical to what `kubernetes` would return on an IPv4-only cluster.

**Caveat, also in a comment in the manifest:** this is a `.`-wide blackhole with no `fallthrough`, failing silently as NODATA rather than as an error. Remove it before introducing IPv6 or reaching any IPv6-only external host.

## `servfail 0`

CoreDNS caches SERVFAIL for 5s and replays it to retrying clients. Upstream failures here are intermittent and the same names resolve on retry, so caching them only widens the blast radius.

## `priorityClassName: system-cluster-critical`

The deployment had no priority class, so under node memory pressure the kubelet could evict cluster DNS ahead of ordinary workloads.

## Validation

`helm template` against chart 1.47.0 renders cleanly and keeps `{{ .Zone }}` intact — the chart uses `{{ .configBlock | indent 12 }}` with no `tpl`. Plugin ordering checked against `plugin.cfg` at `v1.14.6` rather than taken from the upstream PR. Booting `coredns:1.14.6` against the rendered Corefile was not possible locally, so Konflate's render was the gate.

After merge: HelmRelease `UpgradeSucceeded`, 2/2 ready, 0 restarts; both hosts above now resolve IPv4-only; `ghcr.io` still returns HTTP 401 and in-cluster resolution is unaffected.

*(Opened claiming the render failure was transient and these were hardening only. Both were wrong — it reproduced, and this fixed it.)*