### PR TITLE
chore: remove leftover volsync references and pin the kopiur cli

### DIFF
--- a/.agents/skills/add-app/SKILL.md
+++ b/.agents/skills/add-app/SKILL.md
@@ -12,7 +12,7 @@ structure:
 
 | Reference app                       | Shows                                                                                       |
 | ----------------------------------- | ------------------------------------------------------------------------------------------- |
-| `kubernetes/apps/default/atuin`     | Small app: internal route, VolSync-backed PVC, no secrets                                   |
+| `kubernetes/apps/default/atuin`     | Small app: internal route, Kopiur-backed PVC, no secrets                                    |
 | `kubernetes/apps/default/recyclarr` | Config files via `configMapGenerator` + `resources/`                                        |
 | `kubernetes/apps/default/resolute`  | ExternalSecret, SOPS-encrypted config Secret, ServiceMonitor, CronJob, single-writer SQLite |
 | `kubernetes/apps/default/plex`      | Public route on `envoy-external`, Gatus endpoint annotation, LoadBalancer service           |
@@ -44,11 +44,11 @@ Confirm with the user anything not already given:
    justification per `AGENTS.md`).
 4. **Persistence**: choose backup posture from the app's value and recovery
    requirements, not from the presence of a PVC. Protected application state
-   (the norm in the `default` namespace) uses the VolSync component, which
-   wires backups and requires the Rook-Ceph dependency. Some persistent
-   workloads — observability data especially — intentionally use plain PVCs
-   with no VolSync; do not add VolSync coverage just because the app is
-   stateful.
+   (the norm in the `default` namespace) uses the Kopiur component, which
+   supplies the PVC and its backups and requires the Rook-Ceph dependency.
+   Some persistent workloads — observability data especially — intentionally
+   use plain PVCs with no backup coverage; do not add coverage just because
+   the app is stateful.
 5. **Secrets**: an ExternalSecret sourced from 1Password. Get the exact item
    and field names; never guess them.
 6. **Config files**: mounted config uses `configMapGenerator` plus a
@@ -77,9 +77,9 @@ kubernetes/apps/<namespace>/<app>/
 
 Copy atuin's `ks.yaml`. Keep the key order and drop what does not apply:
 
-- `components` + `dependsOn` (rook-ceph-cluster): only with a VolSync PVC.
-- `postBuild.substitute.APP` is required by the VolSync component; add
-  `VOLSYNC_CAPACITY` when the component default (5Gi) is wrong.
+- `components` + `dependsOn` (rook-ceph-cluster): only with a Kopiur PVC.
+- `postBuild.substitute.APP` is required by the Kopiur component; add
+  `PVC_CAPACITY` when the component default (5Gi) is wrong.
 - `postBuild.substituteFrom: cluster-secrets`: needed for `${SECRET_DOMAIN}`
   and other substituted values, and it only works in namespaces whose
   `kustomization.yaml` includes the SOPS component (`../../components/sops`) —
@@ -107,11 +107,11 @@ Copy atuin's and adapt. Invariants to keep:
 - `spec.values` order: `controllers`, `defaultPodOptions`, `service`, `route`,
   `configMaps`, `persistence` (see
   `.agents/instructions/yaml-ordering.instructions.md`).
-- `defaultPodOptions.securityContext` for VolSync-backed apps only:
+- `defaultPodOptions.securityContext` for Kopiur-backed apps only:
   `runAsNonRoot: true`, `runAsUser: 1032`, `runAsGroup: 100`, `fsGroup: 100`,
-  `fsGroupChangePolicy: OnRootMismatch` — the identity the Restic movers and
+  `fsGroupChangePolicy: OnRootMismatch` — the identity the Kopiur movers and
   the NAS convention expect (`docs/operations/storage-and-backups.md`). Apps
-  without VolSync persistence run whatever identity their image expects; keep
+  without backed-up persistence run whatever identity their image expects; keep
   `runAsNonRoot: true` where the image allows it.
 - Container `securityContext`: `allowPrivilegeEscalation: false`,
   `readOnlyRootFilesystem: true`, `capabilities: { drop: ["ALL"] }`. Add an
@@ -123,7 +123,7 @@ Copy atuin's and adapt. Invariants to keep:
   than the minimum.
 - Route hostnames use `"{{ .Release.Name }}.${SECRET_DOMAIN}"`; never hardcode
   the domain. Public routes get a Gatus endpoint annotation (see plex).
-- VolSync persistence mounts `existingClaim: "{{ .Release.Name }}"`.
+- Kopiur-backed persistence mounts `existingClaim: "{{ .Release.Name }}"`.
 - Config files mount as `type: configMap` with
   `name: "{{ .Release.Name }}-configmap"` (see recyclarr); SOPS-encrypted
   config mounts as `type: secret` (see resolute).

--- a/.github/workflows/renovate-review.yaml
+++ b/.github/workflows/renovate-review.yaml
@@ -280,7 +280,7 @@ jobs:
               context, not action items.
             Treat these one-line diffs as high risk: CRD schema/version/
             `conversion.webhook`; webhook Service/Deployment/certs; RBAC or
-            ServiceAccount; PVC/storage/backup/VolSync/Kopiur; runAsUser,
+            ServiceAccount; PVC/storage/backup/Kopiur; runAsUser,
             runAsGroup, fsGroup, or fsGroupChangePolicy with persistence; routes,
             gateways, ingresses, public hostnames; image digests with unclear
             provenance. For CRD conversion webhooks, verify the webhook Service

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -16,6 +16,11 @@ flux2 = "2.9.3"
 helm = "4.2.3"
 helmfile = "1.7.1"
 just = "1.57.0"
+# Kopiur CLI. Tracks the v1alpha1 CRDs, so keep it on the operator's release;
+# bump it with the kopiur chart, not independently. mise exposes it as
+# `kopiur`, not `kubectl-kopiur`, so invoke it directly rather than as a
+# kubectl plugin.
+"github:home-operations/kopiur" = "0.9.0"
 kubectl = "1.36.3"
 kustomize = "5.8.1"
 lefthook = "2.1.10"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,7 +19,6 @@
     "flux": "folder_kubernetes",
     "talos": "folder_linux",
     "nodes": "folder_server",
-    "volsync": "folder_aws",
     "local": "folder_download",
     "remote": "folder_connection",
     "actions-runner-system": "folder_github",
@@ -33,7 +32,6 @@
     "openebs-system": "folder_database",
     "rook-ceph": "folder_database",
     "system-upgrade": "folder_config",
-    "volsync-system": "folder_aws",
     "alerts": "folder_audit",
     "zeroscaler": "folder_connection",
     "sops": "folder_security"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ small, reviewable, and independently reconcilable.
   inventories.
 - Do not modify ExternalSecret names, target secret names, or secret key names
   unless explicitly requested.
-- Do not casually change PVC names, storage classes, VolSync or Kopiur objects,
+- Do not casually change PVC names, storage classes, Kopiur objects,
   backup schedules, or restore wiring.
 - Do not introduce new operators, CRD families, storage systems, ingress paths,
   or backup systems without a short rationale in the PR or a follow-up note.

--- a/docs/operations/storage-and-backups.md
+++ b/docs/operations/storage-and-backups.md
@@ -156,7 +156,7 @@ restore-test outcomes. Do not disable maintenance.
 
 ## Known Quirks
 
-Observed on 0.7.5 through 0.8.1; re-test on upgrades and file upstream if still
+Observed on 0.7.5 through 0.9.0; re-test on upgrades and file upstream if still
 present when one next bites.
 
 - A `Repository` whose repository-level Job has exhausted `backoffLimit` goes
@@ -172,8 +172,7 @@ present when one next bites.
 - `Maintenance` CR status is unreliable even though maintenance runs correctly:
   `nextScheduledAt` is never written, `lastHandledAt` is skipped for successful
   runs, and `consecutiveFailures` has no writer. Verify maintenance from mover
-  Job history and metrics, not CR status. Still present on upstream `main` as
-  of 2026-07-25.
+  Job history and metrics, not CR status. Still present as of 0.9.0.
 - `Restore` CR status carries no stats. Verify a restore from the target PVC's
   contents, not from the CR.
 - Restore movers emit a non-fatal warning when they cannot read the parent

--- a/kubernetes/apps/default/plex/ks.yaml
+++ b/kubernetes/apps/default/plex/ks.yaml
@@ -19,7 +19,6 @@ spec:
     substitute:
       APP: plex
       PVC_CAPACITY: 50Gi
-      VOLSYNC_CACHE_CAPACITY: 25Gi
     substituteFrom:
       - kind: Secret
         name: cluster-secrets

--- a/kubernetes/apps/observability/grafana/dashboards/home-ops/resources/home-ops-cockpit.json
+++ b/kubernetes/apps/observability/grafana/dashboards/home-ops/resources/home-ops-cockpit.json
@@ -1118,7 +1118,7 @@
         "type": "prometheus",
         "uid": "$${DS_PROMETHEUS}"
       },
-      "description": "VolSync out-of-sync volumes and missed scheduled intervals over the last 24 hours.",
+      "description": "Backup health signals over the last 24 hours.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1167,7 +1167,7 @@
       "id": 54,
       "links": [
         {
-          "title": "VolSync dashboards",
+          "title": "Kopiur dashboards",
           "url": "https://grafana.${SECRET_DOMAIN}/dashboards?query=kopiur",
           "targetBlank": true
         }

--- a/kubernetes/components/kopiur/remote/snapshotschedule.yaml
+++ b/kubernetes/components/kopiur/remote/snapshotschedule.yaml
@@ -8,8 +8,7 @@ spec:
   policyRef:
     name: "${APP}-remote"
   schedule:
-    # Daily in the H 3 window, disjoint from VolSync remote (00:30) and from
-    # both repositories' full maintenance (H 4 local, H 5 remote); timezone
-    # inherits from the repository.
+    # Daily in the H 3 window, ahead of both repositories' full maintenance
+    # (H 4 local, H 5 remote); timezone inherits from the repository.
     cron: "H 3 * * *"
     runOnCreate: false


### PR DESCRIPTION
#1668 removed VolSync's manifests but left 22 references across docs, agent guidance, CI config and editor settings.

Most were cosmetic. One was not: `.agents/skills/add-app/SKILL.md` still told agents to wire new apps to the VolSync component and use `VOLSYNC_CAPACITY`, so any agent adding an app would have emitted a manifest referencing a component that no longer exists. It now points at the Kopiur component and `PVC_CAPACITY`.

| File | Change |
| --- | --- |
| `.agents/skills/add-app/SKILL.md` | wires new apps to Kopiur, not VolSync |
| `AGENTS.md`, `renovate-review.yaml` | VolSync dropped from the sensitive-surface list and review rubric |
| `kubernetes/apps/default/plex/ks.yaml` | dead `VOLSYNC_CACHE_CAPACITY` substitution removed |
| `components/kopiur/remote/snapshotschedule.yaml` | comment justified `H 3` by a VolSync window that no longer exists |
| `home-ops-cockpit.json`, `.vscode/settings.json` | stale panel/link titles and folder icons |
| `docs/operations/storage-and-backups.md` | quirks now read 0.9.0 |

Kept: the retirement record in the storage runbook, and `docs/adr/0001` — ADRs are dated records, not living docs.

## Kopiur CLI pin

`.mise/config.toml` pins the CLI at 0.9.0 to match the operator. It tracks the `v1alpha1` CRDs, so it must move with the chart rather than independently. mise exposes the binary as `kopiur`, not `kubectl-kopiur`, so call it directly rather than as a `kubectl` subcommand.

## Validation

Zero `volsync`/`restic`/`VOLSYNC_*` references outside the two intentional ones. Pinned CLI installs and runs (`kubectl-kopiur 0.9.0`). `just --list` parses, `oxfmt --check` clean, `flate test all` 207 passed, dashboard JSON still 76 panels.