### PR TITLE
fix(grafana): give the cockpit backups panel a real query

### DIFF
--- a/kubernetes/apps/observability/grafana/dashboards/home-ops/resources/home-ops-cockpit.json
+++ b/kubernetes/apps/observability/grafana/dashboards/home-ops/resources/home-ops-cockpit.json
@@ -1118,7 +1118,7 @@
         "type": "prometheus",
         "uid": "$${DS_PROMETHEUS}"
       },
-      "description": "Backup health signals over the last 24 hours.",
+      "description": "Kopiur policies with no successful backup in over 26 hours, or with consecutive failures. 26h clears the daily remote cadence plus jitter.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1195,7 +1195,7 @@
             "uid": "$${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "vector(0)",
+          "expr": "(count((time() - kopiur_policy_last_backup_success_timestamp_seconds) > 93600) or vector(0)) + (count(kopiur_snapshot_consecutive_failures > 0) or vector(0))",
           "instant": true,
           "legendFormat": "Backups",
           "range": false,


### PR DESCRIPTION
The cockpit's Backups panel has been querying `vector(0)` since the VolSync queries were removed in #1668 — a hardcoded zero, so it reads green regardless of backup state. A panel that cannot fail is worse than a missing one.

It now counts real problems, keeping the original shape of "count the problems, 0 if none":

```
(count((time() - kopiur_policy_last_backup_success_timestamp_seconds) > 93600) or vector(0))
+ (count(kopiur_snapshot_consecutive_failures > 0) or vector(0))
```

Two complementary signals: consecutive failures surface immediately at any cadence, and staleness catches a policy that has stopped running without failing. 26h clears the daily remote cadence plus jitter; the hourly local policies are well inside it. Each side is guarded with `or vector(0)` so a missing series cannot blank the sum.

The existing thresholds already fit — 0 green, 1 or more flips.

## Validation

Evaluated against live Prometheus: returns `0` now, and `38` with the staleness threshold forced to 1s, which confirms it actually counts rather than being vacuously green. `flate test all` 207 passed; dashboard JSON re-parsed, 76 panels intact.

Does not close #1669 — the Attention table still has no Kopiur detail rows, and the richer per-policy panels are still worth building.
