### PR TITLE
docs: add a networking section and fix README accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,22 +72,11 @@ for the replicated Ceph pool.
 │   ├── apps/           # Flux-managed applications, grouped by namespace
 │   ├── components/     # Shared Kustomize components, SOPS, alerts, Kopiur
 │   └── flux/cluster/   # Top-level Flux entrypoint used by render tooling
-├── talos/              # Talos config templates and operator commands
+└── talos/              # Talos config templates and operator commands
 ```
 
-Flux enters the cluster at `kubernetes/flux/cluster/ks.yaml`, then reconciles the
-applications under `kubernetes/apps`. Most application directories follow this
-shape:
-
-```text
-kubernetes/apps/<namespace>/<app>/ks.yaml
-kubernetes/apps/<namespace>/<app>/app/kustomization.yaml
-kubernetes/apps/<namespace>/<app>/app/helmrelease.yaml
-kubernetes/apps/<namespace>/<app>/app/ocirepository.yaml
-```
-
-Common additions include `externalsecret.yaml`, `pvc.yaml`, `httproute.yaml`,
-`servicemonitor.yaml`, dashboards, alerts, and app-specific configuration.
+Flux enters the cluster at `kubernetes/flux/cluster/ks.yaml`, then reconciles
+the applications under `kubernetes/apps`.
 
 ## Automation / CI
 
@@ -135,7 +124,7 @@ diagnostics and Talos operations.
   for the Hermes and ToolHive workbench: current surface, boundaries, and the
   cluster-health triage loop.
 - [Storage and Backups](docs/operations/storage-and-backups.md) describes the
-  current backup posture and backup migration criteria.
+  backup posture, the protected application set, and how to verify a restore.
 
 ## Thanks
 
@@ -145,8 +134,8 @@ This repository builds on patterns from
 [bjw-s-labs/home-ops](https://github.com/bjw-s-labs/home-ops), and the
 [Home Operations](https://discord.gg/home-operations) community.
 
-[kubesearch.dev](https://kubesearch.dev/) remains a great way to find examples of
-how others deploy applications in similar clusters.
+[kubesearch.dev](https://kubesearch.dev/) is a great way to find examples of how
+others deploy applications in similar clusters.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ applied by Flux.
   [Konflate](https://github.com/home-operations/konflate), and
   [GitHub Actions](https://github.com/features/actions)
 
+### Hardware
+
+The cluster runs on three Intel NUC 11 Pro i5 nodes. Each node has 64 GiB RAM,
+a 500 GB SATA SSD for system and scratch storage, and a dedicated 1 TB NVMe disk
+for the replicated Ceph pool.
+
 ## Networking
 
 The cluster sits behind a UniFi Dream Machine Pro, which routes and firewalls
@@ -81,12 +87,6 @@ Two ExternalDNS instances keep records in sync:
 
 The result is split-horizon DNS: at home, public hostnames resolve to LAN
 addresses, so traffic to my own services never leaves the network.
-
-### Hardware
-
-The cluster runs on three Intel NUC 11 Pro i5 nodes. Each node has 64 GiB RAM,
-a 500 GB SATA SSD for system and scratch storage, and a dedicated 1 TB NVMe disk
-for the replicated Ceph pool.
 
 ## Key Paths
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,32 @@ applied by Flux.
   [Konflate](https://github.com/home-operations/konflate), and
   [GitHub Actions](https://github.com/features/actions)
 
+## Networking
+
+The cluster sits behind a UniFi Dream Machine Pro, which routes and firewalls
+the network and peers with the cluster over BGP.
+
+Cilium runs with `kubeProxyReplacement` and native routing, and advertises
+LoadBalancer addresses to the gateway over BGP rather than announcing them on
+the local segment. There are no L2 announcements: service addresses are routed,
+so failover follows the routing table instead of gratuitous ARP, and the
+addresses are reachable from anywhere the router will route to.
+
+Those addresses come from a dedicated Services network rather than the client
+network, which keeps cluster service addresses off the segment where laptops and
+phones live and lets them carry their own firewall policy.
+
+### DNS
+
+Two ExternalDNS instances keep records in sync:
+
+- **Private** — every route, synced to the gateway through the
+  [ExternalDNS UniFi webhook](https://github.com/home-operations/external-dns-unifi-webhook).
+- **Public** — only routes on the external Gateway, synced to Cloudflare.
+
+The result is split-horizon DNS: at home, public hostnames resolve to LAN
+addresses, so traffic to my own services never leaves the network.
+
 ### Hardware
 
 The cluster runs on three Intel NUC 11 Pro i5 nodes. Each node has 64 GiB RAM,

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ experiments out of this tree.
 | Understand the AI workbench architecture       | [ADR-0001: AI Home-Ops Workbench](adr/0001-ai-home-ops-workbench.md)                 |
 | Understand the backup storage decisions        | [ADR-0002: Kopiur Backend and Remote Shape](adr/0002-kopiur-backup-storage-shape.md) |
 | Operate or test the Hermes/ToolHive workbench  | [AI Workbench](operations/ai-workbench.md)                                           |
-| Understand backup posture or Kopiur migration  | [Storage and Backups](operations/storage-and-backups.md)                             |
+| Understand backup posture or verify a restore  | [Storage and Backups](operations/storage-and-backups.md)                             |
 | Renew or replace appliance management TLS      | [Appliance TLS](operations/appliance-tls.md)                                         |
 | Reach the cluster when DNS or the router fails | [Talos Access and Break-Glass](operations/talos-access-and-break-glass.md)           |
 

--- a/docs/guides/cluster-model.md
+++ b/docs/guides/cluster-model.md
@@ -9,8 +9,11 @@ surfaces are high-risk to touch. For repository layout and app file shape see
 
 ## How a merged change reaches the cluster
 
-1. Flux follows `main` through the `flux-system` `GitRepository` managed by
-   Flux Operator.
+1. On push to `main`, a GitHub webhook reaches the `github-webhook` `Receiver`,
+   which reconciles the `flux-system` `GitRepository` and Kustomization
+   immediately. Flux follows `main` through that GitRepository, managed by Flux
+   Operator. The configured intervals are drift-correction fallbacks, not the
+   normal path — a merged change does not wait for the next poll.
 2. `kubernetes/flux/cluster/ks.yaml` defines the `cluster-apps` Kustomization.
    It reconciles `./kubernetes/apps`, enables SOPS decryption, and patches
    every child Kustomization with the same decryption and HelmRelease

--- a/docs/operations/ai-workbench.md
+++ b/docs/operations/ai-workbench.md
@@ -206,9 +206,8 @@ If Hermes reports `session terminated (404). need to re-initialize`,
 `MCP event loop is not running`, treat that as a Hermes MCP session lifecycle
 failure. A ToolHive workload replacement invalidates its in-memory Streamable
 HTTP session, but Hermes should detect that on its next keepalive, reconnect,
-and repopulate the MCP tools automatically. Wait one keepalive interval
-(currently 180 seconds), confirm the ToolHive catalog is present on the MCP
-page, then retry the same single-tool smoke prompt. Reload MCP or restart the
+and repopulate the MCP tools automatically. Wait for the catalog to reappear on
+the MCP page, then retry the same single-tool smoke prompt. Reload MCP or restart the
 Hermes gateway only if the catalog does not return or the retry still fails
 with a session-lifecycle error. Model-provider failures occur before the MCP
 call and should be diagnosed separately.


### PR DESCRIPTION
Adds a Networking section to the README and fixes four accuracy problems found while auditing it against peer repositories.

## Networking

Covers what is interesting about the network without publishing it: BGP-advertised LoadBalancer addresses rather than L2 announcements, a dedicated Services network and what it isolates, and the split-horizon DNS that falls out of running two ExternalDNS instances. No addresses, ranges, VLAN identifiers or topology diagram — the finished README greps clean for CIDRs and IPs.

Every claim comes from the manifests: `kubeProxyReplacement: true` and `routingMode: native` in the Cilium HelmRelease, `bgpControlPlane` with a `CiliumBGPClusterConfig`, a `services` LB-IPAM pool, `cloudflare-dns` filtered to `--gateway-name=envoy-external`, and `unifi-dns` running unfiltered.

Five of twelve surveyed peers carry a networking section. Two shapes exist: a folded topology diagram, or hardware models with link speeds and CIDRs. The second publishes what `AGENTS.md` prohibits, so this follows neither — it describes behaviour instead of layout.

## Flux reconciles on push

`cluster-model.md` described the reconcile path starting at "Flux follows `main`", which reads as polling. There is a `github-webhook` `Receiver` that reconciles the `flux-system` GitRepository and Kustomization on push; the configured intervals are drift-correction fallbacks. Nothing said so, and the omission has led agents to wait for a reconcile that had already happened.

## Two numbers that were never verified

`ai-workbench.md` told an operator to wait "one keepalive interval (currently 180 seconds)" after a session-lifecycle failure, and #1298 recorded a 30-minute vMCP session TTL alongside it. Neither is configured in this repository. The vMCP CRD exposes dial, read, write and tool-call timeouts but no session TTL, and there is no Hermes keepalive setting to read — the 180 matches an unrelated `terminal.timeout` in the same ConfigMap.

The recovery instruction now says to wait for the tool catalog to reappear on the MCP page, which is observable without knowing any interval and does not rot on an upgrade. #1298's body is corrected in place.

## Smaller corrections

- The Key Paths tree left `talos/` on a mid-list connector when the volsync directory was removed.
- The README duplicated the app-directory layout already in `docs/guides/app-pattern.md`, verbatim.
- Both README and `docs/README.md` still described the storage doc in terms of a backup migration that finished on 2026-07-25.
- "kubesearch.dev remains a great way" implied a prior state the reader does not share.

## Validation

`oxfmt --check` clean across 478 files. README checked for addresses, CIDRs and VLAN identifiers — none present. Cilium, ExternalDNS and Image Pull claims verified against the manifests and workflow rather than recalled.
