### PR TITLE
docs: state why the Services network isolates, not just that it does

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,11 @@ the local segment. There are no L2 announcements: service addresses are routed,
 so failover follows the routing table instead of gratuitous ARP, and the
 addresses are reachable from anywhere the router will route to.
 
-Those addresses come from a dedicated Services network rather than the client
-network, which keeps cluster service addresses off the segment where laptops and
-phones live and lets them carry their own firewall policy.
+Those addresses come from a dedicated Services network that the nodes hold no
+interface on — they simply advertise routes to it over their primary link.
+Because nothing else lives in that range, reaching a service address can never
+be a local-segment conversation: every client routes via the gateway, which is
+where policy is applied rather than assumed.
 
 ### DNS
 


### PR DESCRIPTION
The Networking section said the Services network "keeps cluster service addresses off the segment where laptops and phones live". That implies the VIPs sit on a separate segment the nodes are attached to. They do not: the machine config has a single DHCP interface with no VLAN sub-interface, and Cilium peers BGP to the gateway at its client-network address. The nodes advertise routes to the Services range over their primary link and hold no presence in it.

The isolation comes from something the old wording missed — nothing else lives in that range, so reaching a service address can never be a local-segment conversation. Every client has to route via the gateway, which is what makes firewall policy enforceable rather than merely declared.

Still no addresses, ranges or VLAN identifiers in the README.