### PR TITLE
docs(operations): re-test break-glass after UniFi OS upgrades

### DIFF
--- a/docs/operations/talos-access-and-break-glass.md
+++ b/docs/operations/talos-access-and-break-glass.md
@@ -24,6 +24,10 @@ If the stable DNS name is unavailable (router or DNS failure):
   (`kubectl --server=https://<node>:6443 ...`). Node identities are in the
   API server certificate by default, so TLS verification still passes.
 
+Re-test both paths after every UniFi OS upgrade. They depend on router
+behaviour that a firmware change can alter, and the failure is silent until the
+moment you need them.
+
 ## Client certificate lifecycle
 
 `just talos cert-check` reports expiry; `just talos cert-renew` renews within


### PR DESCRIPTION
Moves a standing operational trigger out of an unmaintained private todo snapshot and into the document that owns it.

The break-glass paths depend on router behaviour that a firmware upgrade can change, and the failure mode is silent — you discover it at the moment you need the path. It belongs beside the paths themselves rather than in a note dated 2026-07-20 that describes itself as deliberately unmaintained.

This was the only item in that snapshot not already tracked in an issue, a guide, or agent memory, so it is the precondition for deleting the snapshot.