### PR TITLE
fix(observability): correct prometheus retention size and raise memory limit

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -68,12 +68,14 @@ spec:
         scrapeConfigSelectorNilUsesHelmValues: false
         serviceMonitorSelectorNilUsesHelmValues: false
         retention: 14d
-        retentionSize: 50GB
+        # Parsed base-2, so an explicit GiB suffix keeps the next reader out of
+        # the 50GB == 50GiB trap that put this guard above the volume capacity
+        retentionSize: 40GiB
         resources:
           requests:
             cpu: 100m
           limits:
-            memory: 2000Mi
+            memory: 3Gi
         storageSpec:
           volumeClaimTemplate:
             spec:


### PR DESCRIPTION
Two fixes from a review of Prometheus.

## `retentionSize: 50GB` → `40GiB`

**The size-based retention guard was set above the volume capacity, so it could never fire.**

Byte units are parsed base-2, so `50GB` is not 50 decimal GB — it becomes `50GiB`. Confirmed against the running instance via `/api/v1/status/flags`:

```
storage.tsdb.retention.size = 50GiB
storage.tsdb.retention.time = 2w
```

| | bytes |
|---|---:|
| `retention.size` (50 GiB) | 53,687,091,200 |
| PVC filesystem capacity | 52,521,566,208 |

The threshold sat **~1.17 GB above total filesystem capacity**. The volume would hit 100% before a single block was deleted for size — and that is before accounting for the WAL, head chunks and compaction scratch, none of which `retentionSize` governs.

Nothing was actually wrong: usage is 14.7 GB (28%) and the 14d time retention is what binds in practice. But the safety net was inoperative. `40GiB` = 42.95 GB, about 82% of the volume.

Using the explicit `GiB` suffix rather than `40GB` so the base-2 parsing is not a trap for the next reader.

## `memory: 2000Mi` → `3Gi`

The limit is 2000Mi = **1.953 GiB**. Measured against it:

| | GiB | % of limit |
|---|---:|---:|
| 14d max working set | 1.886 | **96.5%** |

It has not been OOMKilled — zero restarts, no OOM terminations — so the pressure has been absorbed rather than crashed. But at a cost: the image sets `GOMEMLIMIT` to 90% of the limit (`auto-gomemlimit.ratio=0.9` = 1.758 GiB), so those peaks run *above* the GC ceiling and pay for it in CPU. 96.5% of a hard limit is not a margin, and the observed max is plausibly clamped *by* the limit rather than reflecting true demand.

Head series sit at ~303k. Node capacity is not a constraint: memory requests are at 65% of allocatable.

`3Gi` is 1.6× the observed peak — sized to this instance's 14d retention rather than copied from a longer-retention deployment. Since only `limits.memory` is set, Kubernetes copies it to `requests.memory` (confirmed on the live pod), so this raises the reservation from 2000Mi to 3Gi.

## Note on rollout

Changing the resource limit rolls the Prometheus StatefulSet pod. Expect a brief scrape gap and a WAL replay on startup. The `retentionSize` change alone would not have required a restart.

## Validation

- `kubectl apply --dry-run=server` against the live CRD accepts `40GiB`, including a negative control — `40Gib` is correctly rejected against the schema pattern, confirming the dry-run actually exercises validation rather than passing vacuously.
- Rendered `Prometheus` CR carries `retentionSize: 40GiB` and `limits.memory: 3Gi`.
- `flate test all` — 207 passed.
