### PR TITLE
chore: cut ceph mon and prometheus-adapter log noise

### DIFF
--- a/kubernetes/apps/observability/prometheus-adapter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/prometheus-adapter/app/helmrelease.yaml
@@ -10,6 +10,9 @@ spec:
     name: prometheus-adapter
   interval: 1h
   values:
+    # Chart default is 4, which logs every request; klog still emits warnings
+    # and errors unconditionally at 1
+    logLevel: 1
     prometheus:
       url: http://prometheus-operated.observability.svc.cluster.local
     rules:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -39,6 +39,8 @@ spec:
           device_failure_prediction_mode: local # requires mgr module
         mgr:
           log_max_recent: "100" # quote
+        mon:
+          mon_cluster_log_level: info # default debug; DBG is 80% of mon output
       cleanupPolicy:
         wipeDevicesFromOtherClusters: true
       crashCollector:


### PR DESCRIPTION
The cluster produces **1,921,717 log lines / 24h**. These two changes drop roughly **958k of them — just under half the total** — without losing anything at WRN or above.

## `mon_cluster_log_level: info` (was the Ceph default, `debug`)

`rook-ceph/mon` emits **1,043,743 lines / 24h**, 54.3% of everything the cluster logs. The breakdown over 24h:

| Level | Lines |
|---|---:|
| `[DBG]` | 833,126 |
| `[INF]` | 8,477 |
| `[WRN]` | 0 |
| `[ERR]` | 0 |

**DBG is 80% of mon output; INF is 0.8%.** Raising the floor to `info` drops the pgmap status chatter and keeps every INF entry — the audit trail for mutating commands, osdmap changes and health transitions. Nothing currently logs at WRN or above, so nothing actionable is at stake.

Verified against the running mons rather than assumed:

```
default: "debug"          <- the Ceph default, not a Rook override
can_update_at_runtime: true
services: ["mon"]
mon_cluster_log_to_stderr: true
```

`mon_cluster_log_to_stderr` being true is why these reach the collector at all, and `can_update_at_runtime` means no daemon restart is needed.

## `logLevel: 1` for prometheus-adapter (was `4`)

**126,983 lines / 24h**, of which **125,206 (98.6%)** are per-request `httplog` access logging. `--v=4` is the chart default rather than a deliberate choice here, and klog still emits warnings and errors unconditionally at `v=1`.

## Deliberately not included

**`rook-ceph/mgr` (154,650 lines / 24h)** — the same pgmap chatter, but the mgr logs it locally at debug level 0, which is unconditional. There is no `clog_to_stderr` equivalent, and the only lever trades off monitoring granularity. That deserves its own decision.

Storage was never the constraint here — the log store sits well inside its volume. This is about signal-to-noise.

## Validation

- `kubectl apply --dry-run=server` against the live `CephCluster` CRD accepts the `cephConfig` map, with a negative control: an int value is correctly rejected with `expected string`, confirming the dry-run exercises the schema.
- Rendered adapter args carry `--v=1`; rendered `CephCluster` carries `mon.mon_cluster_log_level: info`.
- `flate test all` — 207 passed.
