### PR TITLE
fix(actions-runner): scale runners to zero when idle and spread them

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
   values:
     githubConfigUrl: https://github.com/alex-matthews/home-ops
     githubConfigSecret: home-ops-runner-secret
-    minRunners: 1
+    minRunners: 0
     maxRunners: 3
     containerMode:
       type: kubernetes
@@ -27,7 +27,17 @@ spec:
       name: actions-runner-controller
       namespace: actions-runner-system
     template:
+      metadata:
+        labels:
+          runner: *name
       spec:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    runner: *name
+                topologyKey: kubernetes.io/hostname
         containers:
           - name: runner
             image: ghcr.io/home-operations/actions-runner:2.336.0@sha256:281a9a090522fafbf4967f158b8c97d03552b1978b688893c5f7cb1944bc5fe5


### PR DESCRIPTION
## `minRunners: 1` → `0`

The scale set held a runner up around the clock to do nothing — a persistent 25Gi work volume and **53,690 log lines / 24h**, about 2.8% of total cluster log volume, for zero jobs. At `0` a runner spins up only when a job is queued. `maxRunners: 3` is unchanged.

## `podAntiAffinity`

Adds the host-spreading constraint the scale set was missing, so concurrent runners land on different nodes rather than stacking on one.

`requiredDuringScheduling` rather than `preferred` is safe here: the work volume's storage class is `WaitForFirstConsumer`, so the scheduler picks a node satisfying the constraint *first* and the volume provisions there — binding cannot strand a pod on a node the constraint then rejects. With `maxRunners: 3` across three nodes it works out to one runner per node.

The constraint needs a pod label to select on, hence the added `template.metadata.labels`; the anchor renders as `runner: home-ops-runner`.

## Validation

- `kubectl apply --dry-run=server` against the live `AutoscalingRunnerSet`.
- Rendered CR carries `minRunners: 0`, the label, and the affinity block.
- `flate test all` — 207 passed.
