### PR TITLE
feat(talos): cap kubelet parallel image pulls at 3

### DIFF
--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -56,6 +56,7 @@ machine:
     defaultRuntimeSeccompProfileEnabled: true
     disableManifestsDirectory: true
     extraConfig:
+      maxParallelImagePulls: 3 # only honoured while serializeImagePulls is false
       serializeImagePulls: false
       shutdownGracePeriod: 90s
       shutdownGracePeriodCriticalPods: 60s


### PR DESCRIPTION
Sets `maxParallelImagePulls: 3` in the kubelet's `extraConfig`.

The kubelet runs with `serializeImagePulls: false` and no cap, so every pending pull on a node runs concurrently. Confirmed against the live kubelet via `configz`:

```json
{"serializeImagePulls": false, "maxParallelImagePulls": null}
```

`null` means uncapped. A node returning from a reboot, or taking a batch of rescheduled pods, pulls all of them at once and they compete for the same link. `3` bounds that without falling back to serialising.

The field is only honoured while `serializeImagePulls` is false, which is already the case — hence the inline comment, so the two are not decoupled by a later edit.

## Validation

- Rendered and `talosctl validate -m metal` passes; the rendered `extraConfig` carries the new field.
- `apply-config --dry-run` against a control-plane node shows a single added line and no reboot.

Rollout is the usual no-reboot `just talos apply-node` per node, where the kubelet restarts to pick up its config.
