### PR TITLE
feat(thelounge): move to the home-operations image and adopt its storage policy

### DIFF
--- a/kubernetes/apps/default/thelounge/app/helmrelease.yaml
+++ b/kubernetes/apps/default/thelounge/app/helmrelease.yaml
@@ -17,11 +17,27 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/thelounge/thelounge
-              tag: 4.5.2@sha256:8806dd11965c8c07ef209ba884423cc611a37e8d6ee0e128dd55f427486122e0
+              repository: ghcr.io/home-operations/thelounge
+              tag: 4.5.2@sha256:7e18ada1421f341b6b129dbb8e4a307320c34ffe38ceef0799ead7f5a3643dbc
             env:
+              # Already this image's default, kept explicit so a future image
+              # bump cannot relocate the data path silently
               THELOUNGE_HOME: /config/thelounge
-              # Avoid Node 22 dual-stack connection failures for IRC hosts when IPv6 is
+              # Set explicitly rather than left to the image default: a Kubernetes
+              # service-link variable of the same name would otherwise override it
+              THELOUNGE_PORT: &port 80
+              # Adopting this image's storage policy: sqlite only, and a background
+              # task deleting every message older than 30 days. These four are the
+              # image's own defaults, restated here because they delete data — the
+              # retention this cluster keeps should be visible in git rather than
+              # inherited, and an upstream change to the window should be a diff.
+              # They reach thelounge as --config flags, which Config.merge applies
+              # after config.js is read, so they override the config file.
+              THELOUNGE_MESSAGE_STORAGE: "[sqlite]"
+              THELOUNGE_STORAGE_POLICY_ENABLED: "true"
+              THELOUNGE_STORAGE_POLICY_MAX_AGE_DAYS: "30"
+              THELOUNGE_STORAGE_POLICY_DELETION_POLICY: everything
+              # Avoid Node dual-stack connection failures for IRC hosts when IPv6 is
               # resolvable from the pod but not routable from the cluster.
               NODE_OPTIONS: "--no-network-family-autoselection"
               SQLITE_TMPDIR: /tmp
@@ -55,7 +71,7 @@ spec:
       app:
         ports:
           http:
-            port: 9000
+            port: *port
     route:
       app:
         hostnames:


### PR DESCRIPTION
Swaps `ghcr.io/thelounge/thelounge` for `ghcr.io/home-operations/thelounge` at the same `4.5.2`, and adopts the storage policy that image is opinionated about.

The data path does not move. `THELOUNGE_HOME=/config/thelounge` is this image's own default — upstream defaults to `/var/opt/thelounge`, which is why the override existed. It is kept explicit anyway, so a later image bump cannot relocate the PVC contents silently.

## Storage policy — this deletes message history

> [!WARNING]
> On rollout, a background task begins deleting every message older than 30 days. This is intended, not incidental.

The image ships sqlite-only storage plus a 30-day retention task, and its entrypoint passes them as `--config` flags. `Config.merge()` runs *after* `Config.setHome()` reads `config.js`, so those flags beat the config file — which currently sets `storagePolicy.enabled: false`.

The volume justifies it:

| | size |
|---|---:|
| `alex.sqlite3` | **1.7 GB** |
| text logs | ~500 MB |
| **PVC** | 2.2 GB of 4.8 GB (**47%**), climbing |

and the content is overwhelmingly tracker announce traffic — a single `#announce` log is 208 MB. A 30-day window reclaims most of the sqlite and loses little worth keeping.

Two things accepted deliberately:

- **`deletionPolicy` is global, not per-channel.** thelounge has no per-network scoping for `storagePolicy`, so this takes real conversation older than 30 days along with the bot noise.
- **Dropping `text` from `messageStorage` does not reclaim the existing ~500 MB.** `storagePolicy` only prunes sqlite; the text logger simply stops writing. Those files are cleared separately, once this is deployed and nothing is rewriting them.

All four values are the image's own defaults, restated explicitly rather than inherited. They delete data — the retention this cluster keeps should be visible in git, and an upstream change to the window should arrive as a diff rather than as silent extra deletion.

Restore points before rollout: local snapshot 37m, remote 8h, consecutive successes.

## Port — 9000 to 80

The service moves to `80`, matching the `&port 80` anchor the rest of the apps use — 16 of 20 do, and the exceptions are all apps that dictate their own port. thelounge sat on 9000 only because the previous image offered no port control.

`THELOUNGE_PORT` is set explicitly rather than left to the image default, because a Kubernetes service-link variable of the same name would otherwise override it. Confirmed in the running container.

## Validation

Ran the image as a throwaway pod on an `emptyDir` — never the real PVC:

- starts as uid 1032 despite the image's `USER nobody:nogroup` (entrypoint is mode `0755`, so an arbitrary UID can exec it)
- `readOnlyRootFilesystem: true` holds
- serves HTTP 200 on port 80 under Node 24.18.0 — the pod sandbox sets `ip_unprivileged_port_start=0`, so binding 80 needs no added capability
- all five `--config` flags confirmed in that pod's actual argv

`flate test all` 207 passed; server-side dry-run against the live Deployment accepted.

## Not included

`NODE_OPTIONS=--no-network-family-autoselection` is now redundant — AAAA returns `ENODATA` cluster-wide since #1670 — but removing it is pre-existing cleanup rather than part of this migration, and it carries a coupling to that PR's AAAA blackhole worth documenting where someone would find it. Follow-up.
