### PR TITLE
chore(thelounge): drop the dual-stack workaround CoreDNS made redundant

### DIFF
--- a/kubernetes/apps/default/thelounge/app/helmrelease.yaml
+++ b/kubernetes/apps/default/thelounge/app/helmrelease.yaml
@@ -37,9 +37,6 @@ spec:
               THELOUNGE_STORAGE_POLICY_ENABLED: "true"
               THELOUNGE_STORAGE_POLICY_MAX_AGE_DAYS: "30"
               THELOUNGE_STORAGE_POLICY_DELETION_POLICY: everything
-              # Avoid Node dual-stack connection failures for IRC hosts when IPv6 is
-              # resolvable from the pod but not routable from the cluster.
-              NODE_OPTIONS: "--no-network-family-autoselection"
               SQLITE_TMPDIR: /tmp
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -36,6 +36,12 @@ spec:
           # This is a `.`-wide blackhole with no fallthrough and it fails
           # silently as NODATA, not as an error. Remove it before introducing
           # IPv6 or reaching any IPv6-only external host.
+          #
+          # Something now depends on this: thelounge dropped its
+          # --no-network-family-autoselection workaround because this makes the
+          # dual-stack race it guarded impossible. Restore that env var in the
+          # same change that lifts this blackhole, or its IRC connections start
+          # stalling on unroutable AAAA answers again.
           - name: template
             parameters: ANY AAAA
             configBlock: |-


### PR DESCRIPTION
`NODE_OPTIONS=--no-network-family-autoselection` guarded against Node racing an unroutable AAAA answer — IPv6 was resolvable from the pod but not routable from the cluster, so the happy-eyeballs attempt stalled.

#1670 removed the precondition. The `template ANY AAAA` blackhole answers every AAAA locally with NODATA, so no pod ever receives an IPv6 address to race against.

Verified from the thelounge pod rather than assumed:

```
irc.libera.chat  resolve6 -> ENODATA
github.com       resolve6 -> ENODATA
```

and a connect with `autoSelectFamily` left at its default — the behaviour the flag disables — goes straight out over IPv4 with no stall.

## Why this touches CoreDNS

Removing the env var creates a dependency that would otherwise be invisible: lifting the AAAA blackhole silently re-breaks IRC connections here, and once the env var is gone nothing in the thelounge manifest records that.

So the second hunk puts the warning where someone would actually look — beside the existing "remove it before introducing IPv6" caveat in the CoreDNS values:

```
# Something now depends on this: thelounge dropped its
# --no-network-family-autoselection workaround because this makes the
# dual-stack race it guarded impossible. Restore that env var in the
# same change that lifts this blackhole, or its IRC connections start
# stalling on unroutable AAAA answers again.
```

That hunk is comment-only. The rendered Corefile is byte-identical before and after — diffed to confirm — so this does not restart CoreDNS.

## Validation

`flate test all` 207 passed; server-side dry-run against the live Deployment accepted. Rolling this only restarts thelounge.
