### PR TITLE
feat(observability): probe the local Kopiur S3 endpoint

### DIFF
--- a/kubernetes/apps/observability/blackbox-exporter/app/probes.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/probes.yaml
@@ -35,3 +35,22 @@ spec:
     - targetLabel: service
       replacement: blackbox-exporter
       action: replace
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/probe_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: garage
+spec:
+  jobName: garage_probe
+  module: tcp_connect
+  prober:
+    url: blackbox-exporter.observability.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - garage.internal:3900
+  metricRelabelings:
+    - targetLabel: service
+      replacement: blackbox-exporter
+      action: replace


### PR DESCRIPTION
The local Kopiur repository has had no liveness signal since VolSync was retired: if the S3 daemon on the NAS stops answering, the first indication is snapshots failing. A `tcp_connect` probe closes that.

`tcp_connect` rather than `http_2xx` because Garage answers an unauthenticated request with 403, which `http_2xx` scores as a failure. Connection level is the right granularity anyway — the question is whether the daemon is up, not what it returns. Scraping Garage's own metrics would say more, but that endpoint currently hangs; see #1696.

The probe reuses the existing prober and the `service="blackbox-exporter"` relabel, so the existing `BlackboxProbeFailed` rule covers it and no new alert is needed.

Renders as three probes — the LAN ICMP check, the NFS `tcp_connect`, and this one — with the expected job name and target. `flate test all` 207 passed; `oxfmt` clean.
