### PR TITLE
docs: record the CLAUDE.md symlink and drop a closed issue reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,12 @@ small, reviewable, and independently reconcilable.
 This file is the canonical agent entrypoint and the authority on change
 control. Where it and another document disagree, this file wins.
 
+`CLAUDE.md` at the repository root is a symlink to this file. Claude Code
+auto-loads `CLAUDE.md` at session start and has no knowledge of `AGENTS.md`, so
+without the link a session starts with the user's global instructions and none
+of this repository's — including the guide index and the skills below. Edit
+this file; never the link.
+
 `docs/guides/` holds the working references. Each opens with a **When to use**
 line; read only those whose triggers match the task at hand.
 

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -106,8 +106,7 @@ request check. It runs Flate on `main` after changes under `kubernetes/` so
 merge trains can stay lightweight while the applied branch still gets rendered.
 Konflate remains the pull request render and diff gate. Render's failures are
 silent unless watched, and post-merge breakage also surfaces through Flux
-alerts to Alertmanager; whether Render stays is tracked in
-[#1560](https://github.com/alex-matthews/home-ops/issues/1560).
+alerts to Alertmanager.
 
 `mise` owns the repo-local environment and toolchain contract. Use it for
 environment variables, project-specific tool installation, and reproducible


### PR DESCRIPTION
Two small corrections to the guidance itself.

`AGENTS.md` now records why `CLAUDE.md` exists and which of the two to edit. The root symlink landed separately; without a note explaining it, it reads as duplication and invites tidying — which would silently return agents to starting sessions with the user's global instructions and none of this repository's, since Claude Code auto-loads `CLAUDE.md` and has no knowledge of `AGENTS.md`. That is not hypothetical: it is how a session came to report `maintenance-window` as non-existent after looking in `.claude/skills/`, a directory this repo does not use.

`validation.md` cited #1560 as tracking whether the `Render` workflow stays. That issue is closed, so the clause pointed at a decision no longer pending; the surrounding sentences already cover what Render is and how its failures surface. Every other issue reference under `docs/` is a historical citation in an ADR or operations note, where a closed state is correct — those are unchanged.

`oxfmt --check` clean. Docs-only, so no cluster validation per the heuristic in `validation.md`.
