### PR TITLE
docs(agents): drop what the global instructions already say

### DIFF
--- a/.claude/rules/kubernetes-manifests.md
+++ b/.claude/rules/kubernetes-manifests.md
@@ -1,0 +1,16 @@
+---
+paths:
+    - "kubernetes/**/*.yaml"
+    - "kubernetes/**/*.yml"
+---
+
+# Editing manifests here
+
+Read `docs/guides/app-pattern.md` for repository layout and app file shape, and
+`docs/guides/yaml-ordering.md` for key ordering, before shaping a new file or
+reordering an existing one. Follow the surrounding files where the guides are
+silent.
+
+These are triggers, not copies: the guides remain the single home for the
+detail, and this file exists so a session touching a manifest has been told to
+read them rather than having to decide to.

--- a/.claude/rules/sops.md
+++ b/.claude/rules/sops.md
@@ -1,0 +1,13 @@
+---
+paths:
+    - "**/*.sops.yaml"
+    - "**/*.sops.yml"
+---
+
+# SOPS-encrypted files
+
+Never reformat one. The encrypted document shape is intentional, and a
+formatter rewriting it produces a diff that is both unreviewable and lossy.
+
+Editing the plaintext of a secret is a separate decision, covered by the
+ask-first list in `AGENTS.md`.

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
-.claude/
+# .claude/* rather than .claude/, because git cannot re-include anything
+# inside an excluded directory. Path-scoped rules are shared configuration
+# rather than local state: they name the guides a session must read when it
+# touches a matching file.
+.claude/*
+!.claude/rules/
 .private/
 .pytest_cache/
 .venv/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,10 @@ line; read only those whose triggers match the task at hand.
 - `pr-and-issue-writing.md`: issue bodies, pull request descriptions, and
   comments. Read it before posting or editing any GitHub prose.
 
+`.claude/rules/` holds path-scoped triggers. They carry no guidance of their
+own; each names the guides to read when a session touches a matching file, so
+reading them stops depending on someone deciding to. Claude Code only, for now.
+
 `.agents/skills/` holds task recipes such as `add-app`. Load a skill only when
 performing that task. Load `maintenance-window` before planning or executing
 any window that stops workloads, deletes or recreates PVCs, or holds imperative
@@ -57,9 +61,6 @@ cluster state across a merge.
   analyses the chart templates, which is where a chart's surface actually
   changes — release notes describe the code and routinely miss it. See
   `docs/guides/validation.md`.
-- Verify a convention's scope before writing it as a default. Grep the set it
-  actually applies to; a pattern that holds for one component or one app is not
-  a repository-wide rule. State the scoping rule rather than a count.
 
 ## Treat This Repository As Public
 
@@ -112,8 +113,6 @@ Get explicit user approval of the exact action before:
   these by behaviour, not by command name.
 - Copying anything out of a pod. It is state-preserving but can extract data,
   so state the reason first.
-- Editing `main` directly. Use a PR branch for high-risk changes unless the
-  user explicitly approves otherwise.
 - Adding or expanding bespoke scripts, provider systems, permissions, webhooks,
   storage, auth surfaces, or public routes.
 - Introducing new operators, CRD families, storage systems, ingress paths, or
@@ -125,8 +124,7 @@ Get explicit user approval of the exact action before:
 ### Never
 
 - Use `exec`, `cp`, or `port-forward` to read or move secret material.
-- Edit generated outputs, rendered manifests, caches, logs, credentials, or
-  local auth/session state.
+- Edit generated outputs, rendered manifests, caches, or logs.
 - Reformat SOPS-encrypted files; their encrypted document shape is intentional.
 
 ### Imperative state is a lease, not a lock
@@ -169,10 +167,6 @@ guidance every other one ignores.
 - A peer-comparison scoping rule → `docs/guides/peers.md`.
 - A rule that changes what an agent is allowed to do → this file.
 - If nothing owns it, add a guide rather than widening this file.
-
-Record the evidence alongside the rule. The observation that produced it is
-what lets a later reader judge whether it still holds, and a rule with no
-evidence is the first thing to rot.
 
 ## Communication
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,18 @@ small, reviewable, and independently reconcilable.
 This file is the canonical agent entrypoint and the authority on change
 control. Where it and another document disagree, this file wins.
 
-`CLAUDE.md` at the repository root is a symlink to this file. Claude Code
-auto-loads `CLAUDE.md` at session start and has no knowledge of `AGENTS.md`, so
-without the link a session starts with the user's global instructions and none
-of this repository's — including the guide index and the skills below. Edit
-this file; never the link.
+Edit this file, never the `CLAUDE.md` link beside it.
+
+<!--
+CLAUDE.md at the repository root is a symlink to this file. Claude Code loads
+CLAUDE.md at session start and does not read AGENTS.md, so without the link a
+session starts with the user's global instructions and none of this
+repository's. Verified against the Claude Code memory documentation on
+2026-08-03, which recommends the symlink for exactly this case.
+
+Block-level HTML comments are stripped before this file enters context, so this
+explanation costs nothing to keep here.
+-->
 
 `docs/guides/` holds the working references. Each opens with a **When to use**
 line; read only those whose triggers match the task at hand.
@@ -39,8 +46,8 @@ cluster state across a merge.
   Keep this short when immediate implementation is requested.
 - Read the relevant manifests, workflows, docs, or scripts before proposing a
   fix.
-- Keep changes close to the requested scope. If a branch or PR is the active
-  iteration surface, amend that branch rather than accumulating work on `main`.
+- If a branch or pull request is the active iteration surface, amend it rather
+  than accumulating work on `main`.
 - If a Renovate PR has human companion commits, do not rebase it or let Renovate
   rewrite it unless the user accepts that risk.
 - Compare against peer or upstream patterns where one exists, using the catalog
@@ -141,19 +148,20 @@ on state asserted earlier in the session.
   tools directly unless there is a specific reason to do otherwise.
 - Use `mise exec -- <tool> ...` when invoking repo-pinned tools that may not be
   available on the ambient `PATH`.
-- Use Conventional Commit titles: `type(scope): summary`. Keep the subject in
-  the imperative and let the body carry the reasoning.
-- Do not add AI attribution or generated-by trailers to commits, pull request
-  descriptions, or code comments.
+- Keep commit subjects in the imperative.
 
 ## Recording What You Learn
 
 When a session establishes a durable working preference or a non-obvious fact
-about this repository, write it into the document that owns the topic. Do not
-leave it in agent-private memory: other agents and other clients cannot read
-it, so guidance held by one assistant is guidance every other one ignores.
+about this repository, write it into the document that owns the topic.
 
-- A prose, review, or issue-hygiene convention → `docs/guides/pr-and-issue-writing.md`.
+Agent memory is not a home for it. Some harnesses write memory automatically,
+so the rule is not "never use it" but "never let it be the only copy": other
+agents and other clients cannot read it, and guidance held by one assistant is
+guidance every other one ignores.
+
+- A prose, review, or issue-hygiene convention →
+  `docs/guides/pr-and-issue-writing.md`.
 - A cluster, secret, or storage fact → `docs/guides/cluster-model.md`, or the
   relevant note under `docs/operations/`.
 - A caveat about what a check does or does not prove →


### PR DESCRIPTION
The user-scope `AGENTS.md` at `~/.config/agents/AGENTS.md` loads in every session on this machine, so anything restated here is paid for twice and can drift apart independently. A session in this repository loaded 157 lines of global instructions plus 185 of local before any guide or skill, against Anthropic's under-200-per-file guidance and its warning that longer files reduce adherence.

### Cut as already stated globally

Conventional Commit titles and the AI-attribution prohibition, both stated verbatim in the global file. "Keep the subject in the imperative" was not, so it moves up rather than being deleted.

In the safety lists: editing `main` directly, which the global file already forbids by default rather than merely gating; and credentials and local auth state from the Never list, which its Never list already covers. Generated outputs, rendered manifests, caches and logs stay, because those are specific to this repository.

An earlier revision of this branch left the safety-list overlaps in place, on the reasoning that a safety enumeration should stay self-contained. That was wrong for a reason worth recording: belt-and-braces means never finding out whether the global rule is respected. The overlap hides the failure it is insuring against.

### Moved upstream, not deleted

"Verify a convention's scope before writing it as a default" and "record the evidence beside the rule" are general rather than GitOps-specific, and both were better stated here than anywhere in the global file.

### The `CLAUDE.md` explanation

Now a block-level HTML comment. Claude Code strips those before the file enters context, so the reasoning stays for a human opening the file and costs a session nothing. The operative sentence stays in the body. The underlying claim was verified rather than assumed: Claude Code still reads `CLAUDE.md` and not `AGENTS.md`, and its documentation recommends the symlink for this case.

### Memory guidance

"Do not leave it in agent-private memory" instructs against something the harness does unprompted — auto memory is on by default and writes without being asked, so this file cannot prevent the write. The rule that holds is that memory must never be the only copy, which is what it now says.

### Path-scoped rules

`.claude/rules/` now carries triggers for manifest and SOPS work. They hold no guidance of their own: each names the guides to read when a session touches a matching file, so reading `yaml-ordering.md` before reordering YAML stops depending on someone deciding to.

This needed a `.gitignore` change, which is the decision worth reviewing rather than the rules themselves. `.claude/` was ignored wholesale, deliberately — harness-neutral configuration lives in `.agents/` and Claude-specific configuration stays out of the repository. Sharing the rules means accepting one Claude-specific directory in git. The exception is as narrow as possible: `.claude/*` with `!.claude/rules/`, so settings and local state stay ignored.

Worth knowing if this pattern spreads: the obvious form, `.claude/` followed by `!.claude/rules/`, silently does nothing. Git cannot re-include a file inside an excluded directory, so the contents have to be excluded instead.

### Left for you

**Commit bodies.** Both repositories build the squash body from `COMMIT_MESSAGES`, so the reasoning that lands in `git log` is every commit message concatenated. A recent 19-commit branch produced a 213-line squash body containing an approach that was abandoned two commits later, preserved as prose with nothing marking it as superseded. Subject-only commits would instead leave the durable record with no reasoning at all, because the pull request body is not in git. The fix is probably neither rule but the setting: `PR_BODY` makes the curated, corrected body the permanent record. That would also make one line of `docs/guides/pr-and-issue-writing.md` false.

**Section order.** `Safety Boundaries` is the most consequential content here and sits behind two sections of preamble. Moving it up is the change most likely to affect whether it is recalled deep into a session, and it is structural rather than a cut.

Formatting check passes. No manifest, workflow or cluster state touched.
