### PR TITLE
docs(guides): the pull request body is the only durable record

### DIFF
--- a/docs/guides/pr-and-issue-writing.md
+++ b/docs/guides/pr-and-issue-writing.md
@@ -48,11 +48,18 @@ not.
 
 ### Keeping the body current
 
-The commit messages and the body serve different readers, so write both to fit
-what each carries rather than choosing between them. The squash commit is built
-from the commit messages, so those are what `git log` and `git blame` surface
-later. The body is what a reviewer reads now, what the operator checks while the
-branch is open, and what someone following a link finds afterwards.
+The body is the durable record. The squash commit takes the pull request title
+and body verbatim, so what is written here is what `git log` and `git blame`
+surface later — a reader six months on sees this text and not the commit
+messages, which end at the merge.
+
+That makes an inaccurate body a permanent inaccuracy rather than a temporary
+one. It also means the body should describe where the change landed, not the
+route: a superseded approach explained in the body reads, later, as though it
+were the conclusion.
+
+Commit messages serve review. Keep subjects informative enough to follow the
+branch and leave the argument to the body.
 
 Most pull requests here open and merge within the hour and need no refresh.
 Update the body when one outlives a single sitting: when scope changes, when

--- a/docs/guides/pr-and-issue-writing.md
+++ b/docs/guides/pr-and-issue-writing.md
@@ -48,18 +48,20 @@ not.
 
 ### Keeping the body current
 
-The body is the durable record. The squash commit takes the pull request title
-and body verbatim, so what is written here is what `git log` and `git blame`
-surface later — a reader six months on sees this text and not the commit
-messages, which end at the merge.
+The body is the durable record, and it is the only one. The squash commit takes
+the pull request title and carries no body, so `git log` and `git blame` give a
+reader the subject and the `(#123)` pointer and nothing else. Everything that
+explains a change lives here.
 
-That makes an inaccurate body a permanent inaccuracy rather than a temporary
-one. It also means the body should describe where the change landed, not the
-route: a superseded approach explained in the body reads, later, as though it
-were the conclusion.
+Commit messages serve review only. A squash merge discards them — the branch
+commits never reach `main` — so reasoning written into them is gone at merge.
+Keep subjects informative enough to follow a branch while it is open and leave
+the argument to the body.
 
-Commit messages serve review. Keep subjects informative enough to follow the
-branch and leave the argument to the body.
+The body being the only copy is deliberate. A copy frozen into a commit could
+not be corrected afterwards, so a body that turned out wrong would disagree
+with the commit permanently. One editable record means a correction is the
+record.
 
 Most pull requests here open and merge within the hour and need no refresh.
 Update the body when one outlives a single sitting: when scope changes, when


### PR DESCRIPTION
Both repositories were building the squash body from the concatenated commit messages. A recent nineteen-commit branch produced a 213-line commit body containing an approach abandoned two commits later, preserved as prose with nothing marking it superseded — and that is what `git blame` lands on.

The setting is now `PR_TITLE` with no body, so a squash commit carries the subject and the `(#123)` pointer. This guide said the record was built from commit messages, which was true and is no longer, so it is rewritten.

Two things it now states that were not obvious and cost time to establish.

Branch commits do not reach `main` under a squash merge. Reasoning written into them serves review and is discarded at the merge, so a careful commit body is not a contribution to history. Verified: none of the nineteen commits behind that squash are reachable from `main`.

The body being the only copy is the point rather than a compromise. Freezing it into the commit was the obvious alternative and was rejected: a body that turns out wrong after merge can be corrected on GitHub but not in git, so the two would disagree permanently. One editable record means a correction is the record.

### On losing GitHub

Keeping the reasoning only on GitHub is a dependency, and the obvious hedge — freezing bodies into commits — is a poor one. It captures pull request bodies at merge and nothing else: not issues, not review threads, not corrections made afterwards. If the platform went away, the backlog and every review would go with it while the commits carried a frozen slice.

The instrument that matches that risk is an export of issues, pull requests and comments into somewhere already backed up. Filed separately rather than solved here.
