### PR TITLE
fix(renovate): normalise talos group version titles

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -118,6 +118,12 @@
       minimumGroupSize: 2,
     },
     {
+      description: "Normalise Talos Group version titles",
+      matchPackageNames: ["siderolabs/talos"],
+      matchUpdateTypes: ["major", "minor", "patch"],
+      commitMessageExtra: "({{{replace '^v' '' currentVersion}}} ➔ {{{replace '^v' '' newVersion}}})",
+    },
+    {
       description: "ToolHive Group",
       groupName: "toolhive",
       matchDatasources: ["docker"],


### PR DESCRIPTION
The grouped talos PR title renders without a version range ("update talos group") while every other group shows one. Renovate drops a group's `commitMessageExtra` when the members compile differing extras, and the talos group mixes v-prefixed factory/tuppr values with the bare mise `talosctl` value.

Same fix as the existing "Normalise Flux Operator Group version titles" rule: override `commitMessageExtra` for `siderolabs/talos` to strip the `v`, so all three members compile the identical extra and Renovate keeps it. The next Renovate run retitles #1731 to include `(1.13.7 ➔ 1.13.8)`.

Validation: `renovate-config-validator` (44.13.3) passes; `oxfmt --check` clean.
