### PR TITLE
docs(operations): node rollout expectations and ceph alert-template caveat

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ experiments out of this tree.
 | Operate or test the Hermes/ToolHive workbench  | [AI Workbench](operations/ai-workbench.md)                                           |
 | Understand backup posture or verify a restore  | [Storage and Backups](operations/storage-and-backups.md)                             |
 | Renew or replace appliance management TLS      | [Appliance TLS](operations/appliance-tls.md)                                         |
+| Run or watch a Talos/Kubernetes node rollout   | [Node Upgrades](operations/node-upgrades.md)                                         |
 | Reach the cluster when DNS or the router fails | [Talos Access and Break-Glass](operations/talos-access-and-break-glass.md)           |
 
 ## Placement Rule

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -78,6 +78,17 @@ The `home-ops-cockpit` dashboard already filters to actionable alerts, so when
 it disagrees with a raw Prometheus query, check this distinction before
 concluding the panel is wrong.
 
+During a node reboot that moves a Ceph mgr pod, expect a brief window where
+rook-ceph alert annotations render as the literal text "error expanding
+template" and `PrometheusRuleFailures` fires. Both mgr pods are scraped while
+the old one terminates, the duplicated `ceph_*_metadata` series make the
+rules' `group_left` joins many-to-many, and evaluation plus the annotations'
+inline template queries fail together. Observed on the 2026-08-06 Talos
+rollout; it self-heals when the stale scrape target drops. Confirm with
+`prometheus_rule_evaluation_failures_total` returning to zero rather than
+treating the garbled alert text as new breakage; it is upstream rule
+fragility, not a local rule error.
+
 ## Per-change heuristics
 
 - Workflow or tooling changes: run the formatting and workflow checks above,

--- a/docs/operations/node-upgrades.md
+++ b/docs/operations/node-upgrades.md
@@ -1,0 +1,57 @@
+# Node Upgrades
+
+How Talos and Kubernetes version bumps roll through the nodes, what a healthy
+rollout looks like, and which side effects are expected rather than incidents.
+Baseline observations are from the 2026-08-06 Talos 1.13.7 → 1.13.8 rollout.
+
+## How a rollout runs
+
+Tuppr owns node upgrades. Merging a version bump to
+`kubernetes/apps/system-upgrade/tuppr/upgrades/` is the whole trigger: tuppr
+pre-pulls the installer image on every node, then upgrades one node at a time,
+rebooting each and holding between nodes until its health checks pass. The
+checks are declared on the `TalosUpgrade`/`KubernetesUpgrade` CRs: no Kopiur
+`Snapshot` in phase `Running`, no `Restore` resolving or restoring, and the
+Ceph cluster reporting `HEALTH_OK`. A rollout that appears stalled between
+nodes is usually a gate doing its job — check those three before suspecting
+tuppr.
+
+The 1.13.8 rollout took roughly ten minutes per node including the Ceph
+recovery window, and the Renovate group PR pre-pulls changed images through
+Image Pull before merge, so the reboot window does not include image download
+time.
+
+## Expected side effects per node
+
+- The node goes `NotReady` for the reboot; Ceph dips to `HEALTH_WARN` while
+  its mon and OSD are down and while PGs re-sync afterwards.
+- Mon/OSD-down alerts for the rebooting node fire and self-resolve. If the
+  node hosted a Ceph mgr, alert annotations can briefly render as "error
+  expanding template" — see the alert caveats in
+  [`../guides/validation.md`](../guides/validation.md).
+- Kopiur is unaffected: the repositories are NAS- and R2-backed, both stayed
+  `Ready` through the 1.13.8 rollout, and the circuit breaker did not trip.
+  Backups due mid-rollout are deferred by the tuppr gate, not lost.
+
+## After the rollout: workload spread
+
+The last node upgraded ends the rollout nearly empty — everything drained off
+it has been rescheduled onto the earlier nodes, and nothing moves back on its
+own. The descheduler's `LowNodeUtilization` profile
+(`kubernetes/apps/kube-system/descheduler/`) is what restores balance: it
+compares actual usage from metrics against per-dimension thresholds and
+evicts up to five pods per node per five-minute cycle from overutilized
+nodes. In this cluster CPU and memory sit far below the 50% targets, so the
+pod-count dimension (target 45% of pod capacity) is what actually drives
+rebalancing after a rollout.
+
+Convergence is deliberately gradual — expect balance within a few cycles, not
+immediately. Verify with pods-per-node counts rather than assuming:
+
+```sh
+kubectl get pods -A -o wide --field-selector=status.phase=Running
+```
+
+Balanced per the stated thresholds does not mean numerically equal: the
+descheduler stops evicting once no node exceeds the target thresholds, so a
+residual skew inside the target band is the policy working, not failing.


### PR DESCRIPTION
Records what the 2026-08-06 Talos 1.13.7 → 1.13.8 rollout taught, so the next rollout's side effects read as expected behaviour rather than incidents.

New `docs/operations/node-upgrades.md`: how tuppr runs a rollout (pre-pull, serial reboots, the Kopiur and Ceph health gates and what a "stalled" hold usually means), the expected per-node side effects, and the post-rollout workload spread — the last node ends nearly empty and the descheduler's `LowNodeUtilization` profile refills it at up to five evictions per node per five-minute cycle, driven in practice by the pod-count dimension since CPU/memory sit far below their targets. Verified live: the rollout left m1 with 17 non-DaemonSet pods against ~50 on each other node, and the descheduler converged it back inside the target band within a few cycles.

`docs/guides/validation.md` gains an alert caveat observed during the rollout: a mgr pod handover briefly double-scrapes `ceph_*_metadata`, making the rook-ceph rules' `group_left` joins many-to-many — `PrometheusRuleFailures` fires and alert annotations render as the literal "error expanding template". Self-heals when the stale scrape target drops; confirmation is `prometheus_rule_evaluation_failures_total` returning to zero.

Docs-only; `oxfmt --check` clean.
