### PR TITLE
chore(renovate-config)!: update config home-operations/renovate-presets (5.0.0 ➔ 6.0.0)

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,6 +1,11 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["github>home-operations/renovate-presets#5.0.0", ":timezone(Pacific/Auckland)"],
+  extends: [
+    "github>home-operations/renovate-presets#6.0.0",
+    "github>home-operations/renovate-presets//apps/grafanaDashboards.json5#6.0.0",
+    "github>home-operations/renovate-presets//apps/talosFactory.json5#6.0.0",
+    ":timezone(Pacific/Auckland)",
+  ],
   packageRules: [
     // Auto-merge rules
     {


### PR DESCRIPTION
Closes #1737 

## Why

The `#5.0.0` pin only pinned the entry point. `default.json` at that tag lists its nested presets without a tag, and Renovate resolves each nested reference from the preset repo's default branch. home-operations/renovate-presets#86 moved the app-specific presets out of `managers/` and `versioning/` into an opt-in `apps/` directory, so `default.json@5.0.0` kept asking for `managers/cnpg.json5`, which no longer exists on main. Preset resolution failed and Renovate halted every PR.

## What

Bump to `6.0.0`, whose `default.json` matches the new layout, and explicitly opt into the two `apps/` presets this repo actually needs:

- `apps/grafanaDashboards.json5` - 16 `grafanadashboard.yaml` manifests under `kubernetes/apps/`, plus the existing auto-merge rule that matches the `custom.grafana-dashboards` datasource.
- `apps/talosFactory.json5` - the `factory.talos.dev` installer image in `talos/machineconfig.yaml.j2`, and the rule that stops the generic Docker manager from double-matching it.

`cnpg`, `llamacpp`, `phanpy` and `searxng` also moved but are unused here, so they stay out.

## Verification

N/A