### PR TITLE
docs(kopiur): record 0.10.0 rollout findings

### DIFF
--- a/.github/workflows/renovate-review.yaml
+++ b/.github/workflows/renovate-review.yaml
@@ -138,7 +138,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ env.PR_NUMBER }}
         run: |
-          policy_version="5"
+          policy_version="6"
           review_input="${RUNNER_TEMP}/renovate-review-input.txt"
           review_meta="${RUNNER_TEMP}/renovate-review-pr-meta.json"
           review_file_paths="${RUNNER_TEMP}/renovate-review-file-paths.json"
@@ -260,6 +260,11 @@ jobs:
               If CRDs changed, use this summary to identify affected resources,
               then inspect upstream CRD source diffs and summarize all schema or
               description changes; do not call the impact image-only.
+              This repo's `kubernetes/flux/cluster/ks.yaml` injects
+              `install.crds: CreateReplace` and `upgrade.crds: CreateReplace`
+              into child HelmReleases. Treat chart-shipped CRDs as installed or
+              replaced on upgrade even when the leaf HelmRelease omits those
+              fields; do not assume Helm's default skip behavior.
               Do not fetch, link, name, or quote the interactive Konflate UI,
               configured hostnames, or raw non-GitHub URLs.
               Do not repeat Konflate resource/app/CRD counts anywhere in the

--- a/docs/adr/0002-kopiur-backup-storage-shape.md
+++ b/docs/adr/0002-kopiur-backup-storage-shape.md
@@ -76,5 +76,11 @@ inherits the local cadence and retention wholesale.
 - The pilot's `RepositoryReplication` gates in the storage document are
   superseded; the restore-from-R2 proof moves to the first production app's
   acceptance criteria.
+- Kopiur 0.10.0's `SnapshotReplication` does not supersede the independent R2
+  path. Deriving the off-site copy from Garage would reintroduce the local
+  repository as a shared failure and corruption domain, while combining it
+  with direct R2 backups would create overlapping writers for the same kopia
+  identities. A future replication-only third copy needs its own repository
+  and a new decision record.
 - The pilot repository migrates to the S3 backend during production rollout;
   the NFS pilot export is retired afterwards.

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -60,6 +60,19 @@ advisory. If it flags something this repo documents as intentional, fix the
 reviewer's prompt — it is inline in `.github/workflows/renovate-review.yaml` —
 rather than learning to skip the comment.
 
+## CRD lifecycle in this cluster
+
+The `cluster-apps` Kustomization patches every child Kustomization so its
+HelmReleases receive `install.crds: CreateReplace` and
+`upgrade.crds: CreateReplace`; leaf HelmRelease files therefore omit those
+fields without inheriting Helm's skip-on-upgrade behavior. Chart CRDs in the
+special `crds/` directory are installed and replaced during reconciliation.
+
+When reviewing a chart upgrade, treat shipped CRD schema changes and new CRDs
+as changes that will reach the cluster. Verify the repo-wide patch in
+`kubernetes/flux/cluster/ks.yaml`; do not infer the effective policy from the
+leaf HelmRelease alone or from Helm's default CRD behavior.
+
 ## What a firing alert does not prove
 
 Prometheus reports an alert as firing whether or not it is silenced — silencing

--- a/docs/operations/storage-and-backups.md
+++ b/docs/operations/storage-and-backups.md
@@ -24,7 +24,10 @@ guardrail. Do not route that traffic back through NFS.
 
 The two repositories are independent by design ([ADR-0002](../adr/0002-kopiur-backup-storage-shape.md)):
 no replication between them, so local repository damage cannot propagate
-off-site.
+off-site. Kopiur's `SnapshotReplication` CRD does not change that decision:
+feeding R2 from Garage would make the off-site path depend on the local
+repository, while running replication alongside the direct R2 policies would
+create overlapping writers for the same kopia identities.
 
 ## The Retired VolSync Archive
 
@@ -224,8 +227,10 @@ the repository phase and breaker metrics instead.
 
 ## Known Quirks
 
-Rechecked on 2026-08-06 against 0.9.3 source and the live 0.9.2 release. Re-test
-runtime observations after upgrades and file upstream if one still bites.
+Rechecked on 2026-08-11 against 0.10.0 source. The live rollout verified
+repository, policy, schedule and backup paths; maintenance and restore quirks
+below remain source-verified rather than re-exercised. Re-test runtime
+observations after upgrades and file upstream if one still bites.
 
 - Repository-level movers take their identity from
   `spec.moverDefaults.securityContext`, not from any `SnapshotPolicy`. Left
@@ -234,15 +239,15 @@ runtime observations after upgrades and file upstream if one still bites.
   The mover writes `lastRunAt` only on a real successful run, so that field is
   the success authority. `lastHandledAt` is a yield marker: a successful run
   advances `lastRunAt` first, which un-dues the slot before the controller can
-  record it, so it stays absent on a healthy repository (same code in 0.9.2 and
-  0.9.3 — do not wait for it to appear). `nextScheduledAt` and
+  record it, so it stays absent on a healthy repository (unchanged in 0.10.0 —
+  do not wait for it to appear). `nextScheduledAt` and
   `consecutiveFailures` have no writers, and `lastContentReclaimedBytes` is
   hard-coded to zero, as is the gauge mirroring it. There are no maintenance
   success or duration metrics, and mover metrics are OTLP-push-only and not
   exported here. Verify from `lastRunAt` plus Job history, noting maintenance
   Jobs self-reap one hour after finishing.
 - `Restore` exposes `status.progress`, but the mover deliberately does not
-  populate it as of 0.9.3, and terminal status carries no stats. Verify a
+  populate it as of 0.10.0, and terminal status carries no stats. Verify a
   restore from the target PVC's contents, not from CR counters.
 - Restore movers warn `status.resolved read failed` on every `fromPolicy`
   restore: the mover GETs the parent `Restore` main resource, but its RBAC
@@ -252,10 +257,14 @@ runtime observations after upgrades and file upstream if one still bites.
   upstream fix.
 - A repository whose `<repo>-discovery` Job exhausted `backoffLimit` on a
   terminal-class failure (bad credentials, locked repository) parks
-  `Failed`/`Stalled` and does not retry a spec or Secret fix until the finished
-  Job's TTL reaps it, two hours by default; deleting the Job retries
-  immediately. From 0.9.3, outage-class failures instead recycle automatically
-  into the `Degraded` retry loop and need no intervention.
+  `Failed`/`Stalled`. From 0.10.0, a spec edit changes the repository generation
+  and immediately recycles a stale generation-stamped Job. A Secret-only
+  credential fix does not change the generation and still waits for the
+  finished Job's TTL, two hours by default; deleting the Job retries
+  immediately. One terminal Job created before the 0.10.0 upgrade has no
+  generation stamp and can behave the old way once. From 0.9.3, outage-class
+  failures instead recycle automatically into the `Degraded` retry loop and
+  need no intervention.
 - Persistent mover-cache PVCs are create-only. Changing `mover.cache.capacity`
   affects new claims only; expand an existing cache through the PVC and expect
   `FileSystemResizePending` until the next mover mount completes the resize. A


### PR DESCRIPTION
Kopiur 0.10.0 rolled out cleanly after #1752: the operator and repositories reconciled, the first scheduled backups succeeded, the revised Prometheus rules evaluated without failures, and existing single-repository metrics retained their label sets.

This records the remaining 0.10.0 quirks, narrows immediate bootstrap retry to generation-changing spec edits, and documents why SnapshotReplication does not replace the independent R2 path. It also records the repo-wide `CreateReplace` CRD policy and teaches the Renovate reviewer to apply it, with a policy-version bump so future reviews use the new instruction.

Formatting, actionlint, zizmor, and staged-diff validation passed.