### PR TITLE
docs(github): add issue templates and shape routing

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/design-proposal.md
+++ b/.github/ISSUE_TEMPLATE/design-proposal.md
@@ -1,0 +1,43 @@
+---
+name: Design proposal
+about: Decide policy, architecture, or new systems when alternatives and trade-offs matter.
+---
+
+<!--
+One line per paragraph; let the browser wrap. Delete any section that does not apply.
+Writing standards, template routing, and the public-safety checklist: docs/guides/pr-and-issue-writing.md.
+-->
+
+<!-- Lead paragraph, no heading: one to three sentences stating the decision to be made and the recommended direction. -->
+
+## Problem
+
+<!-- Why a decision is needed now. Include the concrete situation, not just the abstract concern. -->
+
+## Goals
+
+<!-- What a good outcome achieves, stated so alternatives can be judged against it. -->
+
+## Non-goals
+
+<!-- What this decision deliberately does not cover, so discussion stays focused. -->
+
+## Proposal
+
+<!-- The recommended approach, in enough detail that a reader can see how it works and what it touches. -->
+
+## Alternatives
+
+<!-- Each considered alternative, its trade-offs, and why it was not selected. -->
+
+## Risks and mitigations
+
+<!-- What could go wrong, how likely, and what limits the damage. -->
+
+## Rollout and validation
+
+<!-- How the change lands, what proves it works, and what reverses it. -->
+
+## Completion criteria
+
+<!-- What must be true to close. Keep this body current as the decision evolves; it is the record. -->

--- a/.github/ISSUE_TEMPLATE/operational-investigation.md
+++ b/.github/ISSUE_TEMPLATE/operational-investigation.md
@@ -1,0 +1,51 @@
+---
+name: Operational investigation
+about: Investigate observed operational behaviour and track evidence-led corrections.
+---
+
+<!--
+One line per paragraph; let the browser wrap. Delete any section that does not apply.
+Writing standards, template routing, and the public-safety checklist: docs/guides/pr-and-issue-writing.md.
+-->
+
+<!-- Lead paragraph, no heading: one to three sentences stating what was observed and, once known, what this issue changes. An open investigation can start with the Problem section alone and grow the rest as diagnosis lands. -->
+
+## Problem
+
+<!-- The observed behaviour that prompted the investigation, with measurements. Lead with the concrete observation, then why it matters. -->
+
+## Diagnosis
+
+<!-- The mechanism behind the observation. Delete this section if Problem already carries it. -->
+
+## Proposal
+
+<!-- The corrective change, once the diagnosis supports one. Evidence tables belong here: current value, measured basis, proposed value. -->
+
+## Expected outcome
+
+<!-- What improves, what deliberately does not, and the projected end state. -->
+
+## Non-goals
+
+<!-- Scope boundaries a reader might otherwise assume are included. State why each is excluded. -->
+
+## Evidence and caveats
+
+<!-- Measurement window, methodology, and what the evidence cannot show. -->
+
+## Rollout
+
+<!-- Checkboxes for the work this issue owns, in order, with gates. -->
+
+## Follow-up work
+
+<!-- Checkboxes for deferred work, phrased as "open a follow-up to ...". Give each enough context here to stand alone. If the real work is mostly in the follow-ups, use the umbrella template instead. -->
+
+## Rollback signals
+
+<!-- Conditions that pause or revert the work, and how to tell them apart from noise. -->
+
+## Completion criteria
+
+<!-- What must be true to close. Keep this body current as work lands; it is the record. -->

--- a/.github/ISSUE_TEMPLATE/umbrella.md
+++ b/.github/ISSUE_TEMPLATE/umbrella.md
@@ -1,0 +1,31 @@
+---
+name: Umbrella
+about: Coordinate independent child issues that share scope, sequencing, and cross-child decisions.
+---
+
+<!--
+One line per paragraph; let the browser wrap. Delete any section that does not apply.
+Writing standards, template routing, and the public-safety checklist: docs/guides/pr-and-issue-writing.md.
+-->
+
+<!-- Lead paragraph, no heading: one to three sentences stating what the programme achieves and why it exists now. -->
+
+## Scope
+
+<!-- What is in and what is out. Record scope at creation; make later scope changes explicit in this section rather than silently adding children. -->
+
+## Decisions and constraints
+
+<!-- Cross-child decisions and the invariants every child must honour. Children link back here rather than restating them. -->
+
+## Children
+
+<!-- One row per child, in intended order. Link each issue or PR when it exists and keep status current. Anything with its own evidence, rollout, or rollback belongs in a child, not here. -->
+
+|   # | Work | Depends on | Issue/PR | Status |
+| --: | ---- | ---------- | -------- | ------ |
+|   1 |      |            |          |        |
+
+## Completion criteria
+
+<!-- Every child completed or explicitly dropped, with drops and their rationale recorded as decisions above; the cross-child outcome validated, not just the children closed; and this body reflecting the final state. -->

--- a/docs/guides/pr-and-issue-writing.md
+++ b/docs/guides/pr-and-issue-writing.md
@@ -35,6 +35,22 @@ suggested order, status) once there are more than a few findings, and keep the
 raw topology, addresses and identifiers out of it; those belong in local scratch
 or private notes, per **Public safety** below.
 
+### Choosing a shape
+
+Most small issues need no template — a few sentences of prose is the whole
+body. Larger work starts from a template in `.github/ISSUE_TEMPLATE/`:
+
+- **Operational investigation**: observed behaviour that needs evidence, a
+  diagnosis, and possibly a correction.
+- **Design proposal**: a decision among materially different approaches, with
+  goals, non-goals, and trade-offs.
+- **Umbrella**: independently deliverable children where no single child owns
+  the shared scope, sequencing, and cross-child decisions. The umbrella
+  coordinates; it never implements.
+
+Templates are starting shapes: delete sections that do not apply, and rename a
+heading when that makes its contents more accurate.
+
 ## Pull requests
 
 Open with the substance in a sentence or two. No summary preamble, no restating


### PR DESCRIPTION
Adds three issue templates — operational investigation, design proposal, umbrella — with a chooser config that keeps blank issues enabled, and a routing section in the writing guide that owns classification: most small issues need no template, and templates are starting shapes whose sections may be deleted and whose headings may be renamed when that makes their contents more accurate.

The shapes were settled while drafting #1765. The operational shape carries evidence-led sections (problem, diagnosis, proposal with evidence tables, rollback signals); the design shape carries goals, alternatives, and risks; the umbrella is selected by ownership rather than child count — it coordinates children that share scope, sequencing, and cross-child decisions, never implements work itself, records scope changes explicitly, and completes only when the cross-child outcome is validated, not merely when children close.

The chooser descriptions stay to one line each; the guide is the single source of truth for when each template applies.
