### PR TITLE
fix(descheduler): balance on requested resources to stop eviction loop

### DIFF
--- a/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
@@ -13,8 +13,6 @@ spec:
     kind: Deployment
     deschedulerPolicyAPIVersion: descheduler/v1alpha2
     deschedulerPolicy:
-      metricsProviders:
-        - source: KubernetesMetrics
       profiles:
         - name: Default
           pluginConfig:
@@ -30,16 +28,13 @@ spec:
               args:
                 evictionLimits:
                   node: 5
-                metricsUtilization:
-                  source: KubernetesMetrics
+                useDeviationThresholds: true
                 thresholds:
-                  cpu: 20
-                  memory: 20
-                  pods: 35
+                  cpu: 10
+                  memory: 10
                 targetThresholds:
-                  cpu: 50
-                  memory: 50
-                  pods: 45
+                  cpu: 10
+                  memory: 10
             - name: RemoveFailedPods
               args:
                 reasons:


### PR DESCRIPTION
The descheduler has been evicting pods from m1 every five minutes since at least 2026-08-20 — 964 evictions in 24 hours — and the scheduler places each replacement straight back on m1. Repeated victims include victoria-logs, Grafana, cert-manager, External Secrets, and DNS, causing avoidable availability blips.

The loop is a signal mismatch. `LowNodeUtilization` was classifying nodes on actual utilization (`metricsUtilization: KubernetesMetrics`) plus pod count; with actual cpu/memory idling at ~7%/16–20% on every node, pod count was the only dimension that could trigger (m1 at 47% of the 110-pod capacity vs a 45% target, m2 at 35%). The kube-scheduler's default `NodeResourcesFit` scoring (`LeastAllocated`) places by requested resources, where m1 is the least allocated node (56% cpu / 55% memory vs 70/64 on m2 and 67/65 on m3), so every eviction was undone within the same interval. Descheduler logs confirm the classification: m1 overutilized and m2 underutilized purely on the pods percentage.

This switches the strategy to the default requests-based accounting — the same signal the scheduler scores on — so eviction and replacement placement are designed to converge: removing the `metricsProviders` and `metricsUtilization` blocks, dropping the `pods` dimension (a scheduler capacity filter, not a placement score, so balancing it can never settle), and replacing the absolute thresholds with `useDeviationThresholds` at mean ±10 points for cpu and memory.

On today's allocation the bands are ~54–74% cpu and ~51–71% memory, and all three nodes sit inside them, so steady-state evictions stop immediately. After a drain, the returning node falls well below both lower bands while an absorbing node exceeds an upper band, so automatic post-upgrade redistribution is preserved — this is the cleanest always-on variant, since an actual-utilization policy would classify nothing as overutilized at ~7% usage, and absolute request thresholds would need retuning whenever workload requests shift. That also makes this independent of the request right-sizing planned in #1765, which changes absolute allocation but not deviations from the mean.

Rendered the app with kustomize and ran `flate test all` over the cluster: 207 checks pass. Done criteria after merge: zero sustained steady-state evictions, then verified request-based redistribution without repeated victims across the next node drain or upgrade.

Trade-off: pod-count imbalance (currently 52/38/48) is no longer corrected. That is deliberate — it was never correctable, and pod count is not a load signal here.
