### PR TITLE
docs: simplify networking section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,19 +65,12 @@ for the replicated Ceph pool.
 ## Networking
 
 The cluster sits behind a UniFi Dream Machine Pro, which routes and firewalls
-the network and peers with the cluster over BGP.
+the network.
 
-Cilium runs with `kubeProxyReplacement` and native routing, and advertises
-LoadBalancer addresses to the gateway over BGP rather than announcing them on
-the local segment. There are no L2 announcements: service addresses are routed,
-so failover follows the routing table instead of gratuitous ARP, and the
-addresses are reachable from anywhere the router will route to.
-
-Those addresses come from a dedicated Services network that the nodes hold no
-interface on — they simply advertise routes to it over their primary link.
-Because nothing else lives in that range, reaching a service address can never
-be a local-segment conversation: every client routes via the gateway, which is
-where policy is applied rather than assumed.
+Cilium runs with `kubeProxyReplacement` and native routing, with no L2
+announcements. LoadBalancer addresses come from a dedicated range that no node
+holds an interface on; the nodes advertise routes to it over BGP, so all
+traffic to services goes through the gateway.
 
 ### DNS
 

--- a/docs/guides/cluster-model.md
+++ b/docs/guides/cluster-model.md
@@ -1,6 +1,6 @@
 # Cluster Model
 
-**When to use:** Flux reconcile path, secrets, ExternalSecret, SOPS, `cluster-secrets`, substitution, backups, Kopiur, PVC, UID/GID, mover identity, RWO, replicas, scheduling, descheduler policy, node placement and rebalancing, rolling Talos upgrades, high-risk surfaces.
+**When to use:** Flux reconcile path, secrets, ExternalSecret, SOPS, `cluster-secrets`, substitution, backups, Kopiur, PVC, UID/GID, mover identity, RWO, replicas, scheduling, descheduler policy, node placement and rebalancing, rolling Talos upgrades, service networking, LoadBalancer addresses, BGP, L2 announcements, high-risk surfaces.
 
 How a change reaches the cluster, how secrets and state get there, and which
 surfaces are high-risk to touch. For repository layout and app file shape see
@@ -90,6 +90,24 @@ useful convergence, and similar bursts are expected then. Sustained evictions
 outside an upgrade or recovery event may indicate a policy loop. Changes to
 descheduler policy should preserve equivalent post-upgrade convergence or
 explicitly replace it.
+
+## Service networking
+
+LoadBalancer addresses are advertised to the gateway over BGP only; Cilium's
+L2 announcements are disabled. The addresses come from a dedicated range —
+the `CiliumLoadBalancerIPPool` in
+`kubernetes/apps/kube-system/cilium/app/networking.yaml` — that no node holds
+an interface on; the nodes advertise routes to it over their primary link.
+
+The dedicated range is load-bearing, not cosmetic. If service addresses
+shared the nodes' subnet, hosts on that segment would ARP for them instead of
+routing via the gateway, and with L2 announcements disabled nothing would
+answer. Keeping the range free of real interfaces forces every client —
+including hosts on the nodes' own VLAN — through the gateway, where routing
+and firewall policy are applied, and keeps failover in the routing table
+rather than gratuitous ARP. Do not add real interfaces or other devices to
+this range, and do not move the pool into a subnet that shares an L2
+broadcast domain with the nodes.
 
 ## High-risk surfaces
 


### PR DESCRIPTION
The README's Networking section explained its design at essay length while the rest of the file states facts in a sentence or two. This trims it to the same register — UDM Pro, kube-proxy replacement with native routing, no L2 announcements, LoadBalancer addresses in a dedicated range no node holds an interface on, advertised over BGP. The DNS subsection is unchanged.

The rationale the old section carried was its only written copy, and the dedicated-range constraint guards a real failure mode: with L2 announcements disabled, a host sharing a subnet with service addresses would ARP for them and get no answer, so the range must hold no real interfaces. That moves to a Service networking section in docs/guides/cluster-model.md instead of being deleted, alongside its triggers in the guide's when-to-use line.