### PR TITLE
fix(hermes): bump config schema to 38

### DIFF
--- a/kubernetes/apps/ai/hermes/app/configmap.yaml
+++ b/kubernetes/apps/ai/hermes/app/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   name: hermes-config
 data:
   config.yaml: |
-    _config_version: 33
+    _config_version: 38
     providers:
       litellm:
         name: LiteLLM


### PR DESCRIPTION
Since hermes-agent v2026.8.19, boot runs `scripts/docker_config_migrate.py`, which tries to migrate the config from schema 33 to 38 and fails with `Errno 30` because `/opt/data/config.yaml` is a read-only ConfigMap subPath mount. The boot continues today, but the in-Git config should reach schema 38 before upstream's auto-migration support floor moves past 33.

Reviewed the upstream migration ladder (`hermes_cli/config_migrations.py`, steps 34 through 38) against our config: step 34 resets `display.personality` and personality-rendered `agent.system_prompt`, 35 rewrites `display.background_process_notifications: all`, 36 and 37 lift old `delegation.*` defaults, and 38 strips the legacy Relay plugin from `plugins.enabled`. Our config carries none of those keys, so every step is a no-op and the migration reduces to stamping `_config_version: 38` — which is the whole diff. On the next boot `check_config_version()` returns current >= latest and the migrator exits before attempting any write.

Validated with the app-level kustomize render and `flate test all` (207 passed; only the expected offline secret-substitution warning). Config-only pod roll, safe to merge anytime.