### PR TITLE
feat(smartctl-exporter): alert on NVMe endurance consumption and spare degradation

### DIFF
--- a/kubernetes/apps/observability/smartctl-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/app/prometheusrule.yaml
@@ -48,6 +48,26 @@ spec:
           labels:
             severity: critical
 
+        - alert: SmartDeviceEnduranceConsumed
+          expr: |-
+            smartctl_device_percentage_used >= 95
+          for: 5m
+          annotations:
+            summary: >-
+              Drive {{ $labels.device }} on {{ $labels.instance }} has consumed {{ $value }}% of its rated write endurance; plan replacement
+          labels:
+            severity: warning
+
+        - alert: SmartDeviceSpareDegrading
+          expr: |-
+            smartctl_device_available_spare < 95
+          for: 5m
+          annotations:
+            summary: >-
+              Drive {{ $labels.device }} on {{ $labels.instance }} available spare has dropped to {{ $value }}%, an early wear-failure precursor
+          labels:
+            severity: warning
+
         - alert: SmartDeviceAvailableSpareUnderThreshold
           expr: |-
             smartctl_device_available_spare_threshold > smartctl_device_available_spare


### PR DESCRIPTION
The existing smartctl rules fire only at acute failure stages: the vendor spare threshold, media errors, or a SMART critical warning. There is no earlier signal that a drive is wearing toward replacement.

This adds two warning-severity rules: rated endurance at or above 95% consumed, and available spare below 95%. Both mean a replacement should be planned, not that anything is failing, so they surface in Alertmanager without paging. The acute rules are unchanged.

The motivating case: one OSD drive has consumed 89% of its rated endurance while its peer is at 8% after near-identical host writes, so wear rate depends heavily on the drive model. Neither rule fires at current levels.
