### PR TITLE
fix(renovate): ignore mispushed prompp 3.8.14 tag

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -50,6 +50,12 @@
       matchUpdateTypes: ["minor", "patch"],
       automerge: false,
     },
+    // Version constraints
+    {
+      description: "Ignore the mispushed prompp 3.8.14 tag, which carries the 0.8.10 digest",
+      matchPackageNames: ["docker.io/prompp/prompp"],
+      allowedVersions: "<3.0.0",
+    },
     // Grouping rules
     {
       description: "Actions Runner Controller Group",


### PR DESCRIPTION
The upstream `docker.io/prompp/prompp:3.8.14` tag is not a release — it carries the same digest as `0.8.10` (a mispushed tag, see #1814). Closing the Renovate PR only suppresses one from-version, so each merged 0.8.x patch changes the computed update and Renovate re-proposes the phantom major (#1814, then #1824). Constrain the package to `<3.0.0` until either upstream removes the tag or prompp is replaced, whichever comes first.
