### PR TITLE
fix(unpoller): add startup probe so the initial UniFi fetch can finish

### DIFF
--- a/kubernetes/apps/observability/unpoller/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/unpoller/app/helmrelease.yaml
@@ -39,6 +39,11 @@ spec:
                   timeoutSeconds: 1
                   failureThreshold: 3
               readiness: *probes
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
unpoller crashloops on every fresh start: the process logs `Prometheus is enabled`, then blocks before it binds its listener, and the liveness probe kills it at 30 seconds. A 300s startup probe gives that first fetch room to finish.

Measured cold-start bind time on this cluster is 189 seconds, 63% of the 300s budget, so this ceiling is headroom rather than padding and should not be reduced.

### Validation

`oxfmt --check` passes and `kubectl kustomize` on the app directory renders clean. Rendering app-template 5.1.0 against this HelmRelease's values produces `startupProbe: {tcpSocket: {port: 80}, failureThreshold: 30, periodSeconds: 10}`, with the liveness and readiness probes unchanged.
