### PR TITLE
fix(renovate-review): forbid bare upstream issue refs in the reviewer prompt

### DIFF
--- a/.github/workflows/renovate-review.yaml
+++ b/.github/workflows/renovate-review.yaml
@@ -304,8 +304,14 @@ jobs:
             changed risk surfaces; use Low when material evidence is unavailable.
             Keep the visible summary compact; put detail in `<details>`.
             Do not link the current PR. Use `redirect.github.com` links for
-            upstream evidence; include 1-3 proper Markdown links and no bare
-            `owner/repo#123` refs.
+            upstream evidence; include 1-3 proper Markdown links. Never write a
+            bare `#123` or `owner/repo#123` reference to an upstream issue or
+            PR. A bare `#123` autolinks to this repository, sends the reader to
+            an unrelated local PR, and emits a cross-reference event onto that
+            PR's timeline. Write every upstream reference as a Markdown link
+            that carries the repository in its text, for example
+            `[owner/repo#123](https://redirect.github.com/owner/repo/pull/123)`.
+            A bare `#123` is correct only for this repository's own issues.
             Use this exact structure:
             ```markdown
             <!-- home-ops-renovate-research -->


### PR DESCRIPTION
The reviewer prompt forbids bare `owner/repo#123` refs but says nothing about bare `#123`, so the bot writes the unqualified form in its prose. GitHub then autolinks it to this repository, and the reader following a citation about an upstream fix lands on an unrelated Renovate PR.

This replaces that sentence with an explicit prohibition on both forms, the reason, and the required shape: a Markdown link that carries the repository in its link text, which suppresses autolinking because the text sits inside a link. It leaves the existing `redirect.github.com` instruction alone, and states that a bare `#123` remains correct for this repository's own issues, matching the linking rules in [`docs/guides/pr-and-issue-writing.md`](docs/guides/pr-and-issue-writing.md).

### Validation

`actionlint`, `zizmor --offline .github/workflows`, and `oxfmt --check` all pass, and the file still parses as YAML with the job key intact. The prompt is a heredoc string, so the change cannot be exercised without a live Renovate PR; the next Renovate review comment is the real test.