### PR TITLE
feat(maintainerr): opt out of anonymous telemetry

### DIFF
--- a/kubernetes/apps/default/maintainerr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/maintainerr/app/helmrelease.yaml
@@ -21,6 +21,7 @@ spec:
               tag: 3.25.0@sha256:f96e37e04a5e2da56edc39d96774102599de7d7617e2cc00a49a1581b01be136
             env:
               NODE_OPTIONS: --max-old-space-size=768
+              TELEMETRY: "off"
               TZ: Pacific/Auckland
               UI_HOSTNAME: 0.0.0.0
               UI_PORT: &port 80


### PR DESCRIPTION
Maintainerr 3.25.0 added anonymous weekly telemetry that reports by default. The setting is nullable and only an explicit `false` stops it, so an install that never answers the consent prompt keeps reporting — and in an unattended GitOps deployment nothing ever answers it. This sets the environment override instead.

Upstream feature: https://www.github.com/Maintainerr/Maintainerr/pull/3582

### Validation

`oxfmt --check` passes. Rendering app-template 5.1.0 with these values emits `- name: TELEMETRY` / `value: "off"` in the Deployment, confirming the string survives as `off` rather than being coerced to `false`.
