### PR TITLE
fix(renovate-review): bump policy version so the ref-format change takes effect

### DIFF
--- a/.github/workflows/renovate-review.yaml
+++ b/.github/workflows/renovate-review.yaml
@@ -138,7 +138,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ env.PR_NUMBER }}
         run: |
-          policy_version="6"
+          policy_version="7"
           review_input="${RUNNER_TEMP}/renovate-review-input.txt"
           review_meta="${RUNNER_TEMP}/renovate-review-pr-meta.json"
           review_file_paths="${RUNNER_TEMP}/renovate-review-file-paths.json"


### PR DESCRIPTION
#1847 changed the reviewer prompt but not the policy version, so on any pull request that already carries a review the change has no effect.

The review key is `sha256({title, files, renovateTable, policyVersion, stablePrPatchId})`. The prompt text is not an input to it, and `policy_version` is the only field that represents a change in review policy. When the recomputed key matches the fingerprint in the existing comment the job exits before the model runs, so an already-reviewed pull request whose title, files and patch id are unchanged keeps its old comment and is never re-reviewed under the new prompt.

That is the case for every Renovate pull request currently open. Without this bump, the bare-ref fix would only reach pull requests Renovate creates or rebases from now on, and the existing comments would keep pointing readers at unrelated local pull requests.

Bumping to `7` invalidates the cached keys once, so each open pull request is reviewed again under the corrected prompt.

### Validation

`actionlint` and `oxfmt --check` pass. The effect is observable rather than testable ahead of time: the next review comment on an open Renovate pull request should carry a new fingerprint, and its prose should reference upstream issues as Markdown links rather than as bare `#123`.
