### PR TITLE
feat(sonarr): set allowed hosts and trusted networks

### DIFF
--- a/kubernetes/apps/default/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/sonarr/app/helmrelease.yaml
@@ -26,7 +26,9 @@ spec:
               SONARR__AUTH__REQUIRED: DisabledForLocalAddresses
               SONARR__LOG__DBENABLED: "False"
               SONARR__LOG__LEVEL: info
+              SONARR__SERVER__ALLOWEDHOSTS: "{{ .Release.Name }}.${SECRET_DOMAIN},sonarr.default.svc.cluster.local"
               SONARR__SERVER__PORT: &port 80
+              SONARR__SERVER__TRUSTEDNETWORKS: 10.69.0.0/16
               SONARR__UPDATE__BRANCH: develop
               TZ: Pacific/Auckland
             envFrom:
@@ -46,6 +48,9 @@ spec:
                   httpGet:
                     path: /ping
                     port: *port
+                    httpHeaders:
+                      - name: Host
+                        value: localhost
                   periodSeconds: 10
                   timeoutSeconds: 5
                   failureThreshold: 5


### PR DESCRIPTION
Sonarr 4.0.19.3006 added [hostname validation](https://www.github.com/Sonarr/Sonarr/commit/5f69ab0954) and a [trusted networks setting](https://www.github.com/Sonarr/Sonarr/commit/22f05a4343). Both are unset, so host filtering sits at wildcard and the running instance logs `AllowedHostsCheck: Allowed Hosts is not configured` — which matters here because auth is `DisabledForLocalAddresses`.

- `SONARR__SERVER__ALLOWEDHOSTS`: the route hostname plus `sonarr.default.svc.cluster.local`, which is what prowlarr, recyclarr and resolute all use. Loopback and the pod hostname are always allowed.
- `SONARR__SERVER__TRUSTEDNETWORKS`: the pod subnet, restoring trust of `X-Forwarded-For` from envoy; the upstream change dropped the previously hardcoded RFC1918 trust, so client IPs were logging as the envoy pod IP.
- Readiness probe sends `Host: localhost`; the kubelet otherwise uses the pod IP as the Host header, which host filtering rejects. Liveness and startup are TCP and unaffected.

Verified by rendering app-template 5.1.0 with the updated values.
