### PR TITLE
fix(rook-ceph): rotate cephx daemon keys to aes256k

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -81,6 +81,9 @@ spec:
             memory: 8Gi
       security:
         cephx:
+          daemon:
+            keyRotationPolicy: KeyGeneration
+            keyGeneration: 2 # must exceed the current generation in status.cephx
           csi:
             keyType: aes # aes256k mounts need kernel support; Talos 1.14 backports it
       storage:


### PR DESCRIPTION
Stage 2 of the CVE-2025-30156 remediation, following the v1.20.6/Ceph v20.2.4 upgrade in #1801: opt the daemon keys into `KeyGeneration` rotation at generation 2 (`status.cephx` reads generation 1 across all entities). The v1.20.6 operator rotates the admin, mon, mgr, OSD, crash-collector, and ceph-exporter keys to `aes256k` with rolling restarts; CSI keys stay legacy `aes` until the nodes run a kernel with aes256k support.

This clears `AUTH_INSECURE_SERVICE_KEY_TYPE`, the remaining ERR-severity check, closing the CVE's privilege-escalation path and taking Ceph out of the `HEALTH_ERR` that currently fails the `rook-ceph-cluster` Kustomization health check and holds its dependents.

Verified before opening: all daemons on 20.2.4, all PGs `active+clean`, mons in quorum. Full Flux render passes locally (207 checks).