### PR TITLE
feat(kube-prometheus-stack): replace prompp with upstream Prometheus

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -52,11 +52,16 @@ spec:
               namespace: network
       prometheusSpec:
         externalUrl: https://prometheus.${SECRET_DOMAIN}
-        version: v2.55.1 # override 'unsupported Prometheus version' error
-        image:
-          registry: docker.io
-          repository: prompp/prompp
-          tag: 0.8.11
+        initContainers:
+          # Converts the prompp-format WAL back to vanilla before Prometheus 3
+          # starts; remove once the engine switch is verified (see PR).
+          - name: prompptool
+            image: docker.io/prompp/prompp:0.8.11
+            command: ["/bin/prompptool", "--working-dir=/prometheus", "--verbose", "walpp"]
+            volumeMounts:
+              - name: prometheus-kube-prometheus-stack-db
+                mountPath: /prometheus
+                subPath: prometheus-db
         securityContext:
           runAsNonRoot: true
           runAsUser: 64535


### PR DESCRIPTION
Replaces the prompp fork with the chart's default upstream Prometheus 3.x: removes the image override and the `version: v2.55.1` shim the operator needed to accept the fork's image. Ref #1827.

prompp's historical TSDB blocks are standard Prometheus format, but its WAL is not, and the WAL holds the last ~3 hours of samples. A prompptool initContainer runs the fork's documented reverse migration (`walpp`) on the data volume before Prometheus 3 starts, so both the 14-day history and the WAL tail survive the switch.

The initContainer and the prompp Renovate constraint from #1825 stay for now and are removed in a follow-up PR once the switch is verified. The conversion tool's behaviour on an already-converted WAL is undocumented, so the window with the initContainer in place should stay short.

Preflight baseline (2026-08-29): prompp 0.8.11, 0 targets down, 0 rule-evaluation failures over the last hour, 315k head series. Post-merge verification: the initContainer log shows the conversion completing, `prometheus_build_info` reports 3.x, targets and rule health return to baseline, dashboards render, and a range query spanning the switch returns pre-switch samples.
