### PR TITLE
chore(kube-prometheus-stack): remove prompp WAL-conversion initContainer

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -50,12 +50,6 @@
       matchUpdateTypes: ["minor", "patch"],
       automerge: false,
     },
-    // Version constraints
-    {
-      description: "Ignore the mispushed prompp 3.8.14 tag, which carries the 0.8.10 digest",
-      matchPackageNames: ["docker.io/prompp/prompp"],
-      allowedVersions: "<3.0.0",
-    },
     // Grouping rules
     {
       description: "Actions Runner Controller Group",

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -52,16 +52,6 @@ spec:
               namespace: network
       prometheusSpec:
         externalUrl: https://prometheus.${SECRET_DOMAIN}
-        initContainers:
-          # Converts the prompp-format WAL back to vanilla before Prometheus 3
-          # starts; remove once the engine switch is verified (see PR).
-          - name: prompptool
-            image: docker.io/prompp/prompp:0.8.11
-            command: ["/bin/prompptool", "--working-dir=/prometheus", "--verbose", "walpp"]
-            volumeMounts:
-              - name: prometheus-kube-prometheus-stack-db
-                mountPath: /prometheus
-                subPath: prometheus-db
         securityContext:
           runAsNonRoot: true
           runAsUser: 64535


### PR DESCRIPTION
Cleanup after #1873: the switch to upstream Prometheus 3.14 is verified (0 targets down, 0 rule failures, history intact through the retention window including the converted WAL tail), so the one-shot prompptool initContainer comes out before a pod restart can re-run it on an already-vanilla WAL.

Also deletes the prompp `allowedVersions` Renovate rule from #1825 — no prompp image reference remains for it to guard. Closes #1827.