### PR TITLE
refactor(flux): rely on eventual consistency instead of rook-ceph-cluster dependsOn

### DIFF
--- a/kubernetes/apps/default/agregarr/ks.yaml
+++ b/kubernetes/apps/default/agregarr/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/default/agregarr/app
   postBuild:

--- a/kubernetes/apps/default/atuin/ks.yaml
+++ b/kubernetes/apps/default/atuin/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/default/atuin/app
   postBuild:

--- a/kubernetes/apps/default/autobrr/ks.yaml
+++ b/kubernetes/apps/default/autobrr/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/default/autobrr/app
   postBuild:

--- a/kubernetes/apps/default/bazarr/ks.yaml
+++ b/kubernetes/apps/default/bazarr/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/default/bazarr/app
   postBuild:

--- a/kubernetes/apps/default/brrpolice/ks.yaml
+++ b/kubernetes/apps/default/brrpolice/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/default/brrpolice/app
   postBuild:

--- a/kubernetes/apps/default/maintainerr/ks.yaml
+++ b/kubernetes/apps/default/maintainerr/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/default/maintainerr/app
   postBuild:

--- a/kubernetes/apps/default/plex/ks.yaml
+++ b/kubernetes/apps/default/plex/ks.yaml
@@ -11,8 +11,6 @@ spec:
   dependsOn:
     - name: intel-gpu-resource-driver
       namespace: kube-system
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/default/plex/app
   postBuild:

--- a/kubernetes/apps/default/prowlarr/ks.yaml
+++ b/kubernetes/apps/default/prowlarr/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/default/prowlarr/app
   postBuild:

--- a/kubernetes/apps/default/qbittorrent/ks.yaml
+++ b/kubernetes/apps/default/qbittorrent/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/default/qbittorrent/app
   postBuild:

--- a/kubernetes/apps/default/qui/ks.yaml
+++ b/kubernetes/apps/default/qui/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/default/qui/app
   postBuild:

--- a/kubernetes/apps/default/radarr-se/ks.yaml
+++ b/kubernetes/apps/default/radarr-se/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/default/radarr-se/app
   postBuild:

--- a/kubernetes/apps/default/radarr/ks.yaml
+++ b/kubernetes/apps/default/radarr/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/default/radarr/app
   postBuild:

--- a/kubernetes/apps/default/recyclarr/ks.yaml
+++ b/kubernetes/apps/default/recyclarr/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/default/recyclarr/app
   postBuild:

--- a/kubernetes/apps/default/resolute/ks.yaml
+++ b/kubernetes/apps/default/resolute/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/default/resolute/app
   postBuild:

--- a/kubernetes/apps/default/sabnzbd/ks.yaml
+++ b/kubernetes/apps/default/sabnzbd/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/default/sabnzbd/app
   postBuild:

--- a/kubernetes/apps/default/seerr/ks.yaml
+++ b/kubernetes/apps/default/seerr/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/default/seerr/app
   postBuild:

--- a/kubernetes/apps/default/sonarr/ks.yaml
+++ b/kubernetes/apps/default/sonarr/ks.yaml
@@ -8,9 +8,6 @@ spec:
   components:
     - ../../../../components/kopiur
     - ../../../../components/zeroscaler
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/default/sonarr/app
   postBuild:

--- a/kubernetes/apps/default/tautulli/ks.yaml
+++ b/kubernetes/apps/default/tautulli/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/default/tautulli/app
   postBuild:

--- a/kubernetes/apps/default/thelounge/ks.yaml
+++ b/kubernetes/apps/default/thelounge/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/default/thelounge/app
   postBuild:

--- a/kubernetes/apps/observability/grafana/ks.yaml
+++ b/kubernetes/apps/observability/grafana/ks.yaml
@@ -23,8 +23,6 @@ metadata:
 spec:
   dependsOn:
     - name: grafana
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/observability/grafana/instance
   postBuild:

--- a/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: kube-prometheus-stack
 spec:
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/observability/kube-prometheus-stack/app
   postBuild:

--- a/kubernetes/apps/observability/victoria-logs/ks.yaml
+++ b/kubernetes/apps/observability/victoria-logs/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: victoria-logs
 spec:
-  dependsOn:
-    - name: rook-ceph-cluster
-      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/observability/victoria-logs/app
   postBuild:


### PR DESCRIPTION
Removes the `dependsOn: rook-ceph-cluster` edge from 22 app Kustomizations (19 in `default/`, 3 in `observability/`) and relies on eventual consistency for storage ordering instead. First removal batch from the #1872 dependsOn audit.

Rationale:

- No app Kustomization contains rook-owned CRDs or CRs, so every manifest applies with or without Ceph. At bootstrap, PVCs sit Pending until the CSI driver and `ceph-block` StorageClass appear, then everything binds and starts. Kubernetes handles the ordering natively.
- The dependency actively hurts during storage maintenance: `rook-ceph-cluster` has a `healthCheckExprs` that marks it failed on `HEALTH_ERR`, so all dependents are blocked from reconciling while Ceph is unhealthy. The CVE-2025-30156 key rotation (#1801, #1868) put the cluster in an expected, benign `HEALTH_ERR` on 2026-08-28, during which none of these apps could apply changes.
- `dependsOn` only gates applying new manifests; it never protects already-running workloads.

Impact:

- App updates, drift correction and pruning for these apps now proceed regardless of Ceph health.
- The `rook-ceph-cluster` Kustomization keeps its own health checks; the health expression remains useful as a signal without gating unrelated apps.
- Kopiur ordering is unaffected because none existed to lose: the 19 `default/` apps render kopiur CRs, but had neither a direct kopiur edge nor a transitive guarantee through `rook-ceph-cluster`. That pre-existing gap is addressed in #1878.

Validation: formatting and baseline rendering passed; all 78 Kustomizations and the inspected HelmReleases were Ready before merge. Post-merge convergence was verified: every Kustomization reconciled at the merged revision, HelmReleases Ready, no workload restarts, no PVC changes.

Fresh-bootstrap behaviour remains unverified, tracked in #1872: without the edge, a Helm install that times out waiting on storage can stall rather than self-heal once storage appears.
