### PR TITLE
feat(bootstrap): install kopiur and snapshot-controller CRDs at bootstrap

### DIFF
--- a/bootstrap/helmfile/crds.yaml
+++ b/bootstrap/helmfile/crds.yaml
@@ -5,6 +5,10 @@
 # from upstream Helm charts and applying them directly with kubectl. The releases
 # below are never reconciled with helmfile apply or helmfile sync, only their
 # CRDs are rendered (via --include-crds) and piped to the cluster.
+#
+# Installing CRDs out-of-band ensures they exist before Flux begins reconciling
+# workloads that reference them, avoiding the need for dependsOn chains on
+# nearly every Kustomization that consumes a CRD-backed resource.
 
 helmDefaults:
   args:
@@ -28,5 +32,11 @@ releases:
     labels:
       app: grafana
 
+  - name: kopiur
+    namespace: kopiur-system
+
   - name: kube-prometheus-stack
     namespace: observability
+
+  - name: snapshot-controller
+    namespace: kube-system


### PR DESCRIPTION
Follow-up to #1877, from the #1872 dependsOn audit: closes the two gaps the audit found where manifests consume a CRD with nothing ordering its provider first, by installing the missing CRDs out-of-band at bootstrap.

- Adds kopiur to `bootstrap/helmfile/crds.yaml`. The 19 `default/` apps render kopiur CRs (SnapshotSchedule, SnapshotPolicy, Restore) with nothing ordering kopiur first. With the CRDs present from bootstrap, those manifests apply before the kopiur controller exists, and PVC populator semantics (`dataSourceRef` -> `Restore`) hold PVCs Pending until kopiur acts, so no ordering edge is needed. Verified `helmfile -l name=kopiur template` renders all 9 kopiur CRDs.
- Adds snapshot-controller to the same file. The `rook-ceph-cluster` chart renders VolumeSnapshotClass objects with no dependency on snapshot-controller, and on a fresh bootstrap nothing guarantees the snapshot CRDs exist before that chart installs. With the CRDs present from bootstrap, the install no longer depends on reconcile order. Verified 6 CRDs render, including `volumesnapshotclasses`.
- Both entries resolve chart and version through the existing helmfile template from each app's `app/ocirepository.yaml`, matching the grafana-operator / kube-prometheus-stack pattern, so pinned versions and Renovate bumps track automatically. The file's header comment now records the design rationale.

### What this does not change for kopiur

- Repository connection: guarantees are unchanged — nothing depends on `kopiur-repositories`, and Restore handling of an unavailable repository is kopiur's concern rather than a Flux graph concern.
- Admission: not covered — kopiur's webhooks fail closed, so between the webhook configuration being applied and its controller becoming ready, kopiur CRs can be rejected. Flux retries and converges, but a first apply may not succeed on the first pass.
- Data: not covered — CRDs get manifests applied, not data restored. A Restore still needs a matching backup, and `onMissingSnapshot: Fail` makes a missing one a terminal failure requiring manual recovery.

Fresh-bootstrap convergence and an executed CRD schema upgrade stay tracked in #1872.

No runtime effect on the live cluster; the CRDs already exist there, and this file is used only during bootstrap.
