### PR TITLE
refactor(flux): remove availability-gating dependsOn edges

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
@@ -21,10 +21,6 @@ kind: Kustomization
 metadata:
   name: actions-runner-controller-runners
 spec:
-  dependsOn:
-    - name: actions-runner-controller
-    - name: openebs
-      namespace: openebs-system
   interval: 1h
   path: ./kubernetes/apps/actions-runner-system/actions-runner-controller/runners
   prune: true

--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/dragonfly
-  dependsOn:
-    - name: dragonfly-operator
-      namespace: database
   interval: 1h
   path: ./kubernetes/apps/ai/litellm/app
   postBuild:

--- a/kubernetes/apps/ai/mcp/context7-mcp/ks.yaml
+++ b/kubernetes/apps/ai/mcp/context7-mcp/ks.yaml
@@ -5,8 +5,6 @@ kind: Kustomization
 metadata:
   name: context7-mcp
 spec:
-  dependsOn:
-    - name: toolhive-config
   interval: 1h
   path: ./kubernetes/apps/ai/mcp/context7-mcp/app
   prune: true

--- a/kubernetes/apps/ai/mcp/flux-mcp/ks.yaml
+++ b/kubernetes/apps/ai/mcp/flux-mcp/ks.yaml
@@ -5,8 +5,6 @@ kind: Kustomization
 metadata:
   name: flux-mcp
 spec:
-  dependsOn:
-    - name: toolhive-config
   interval: 1h
   path: ./kubernetes/apps/ai/mcp/flux-mcp/app
   prune: true

--- a/kubernetes/apps/ai/mcp/github-mcp/ks.yaml
+++ b/kubernetes/apps/ai/mcp/github-mcp/ks.yaml
@@ -5,8 +5,6 @@ kind: Kustomization
 metadata:
   name: github-mcp
 spec:
-  dependsOn:
-    - name: toolhive-config
   interval: 1h
   path: ./kubernetes/apps/ai/mcp/github-mcp/app
   prune: true

--- a/kubernetes/apps/ai/mcp/grafana-mcp/ks.yaml
+++ b/kubernetes/apps/ai/mcp/grafana-mcp/ks.yaml
@@ -5,10 +5,6 @@ kind: Kustomization
 metadata:
   name: grafana-mcp
 spec:
-  dependsOn:
-    - name: toolhive-config
-    - name: grafana-instance
-      namespace: observability
   interval: 1h
   path: ./kubernetes/apps/ai/mcp/grafana-mcp/app
   prune: true

--- a/kubernetes/apps/ai/mcp/konflate-mcp/ks.yaml
+++ b/kubernetes/apps/ai/mcp/konflate-mcp/ks.yaml
@@ -5,8 +5,6 @@ kind: Kustomization
 metadata:
   name: konflate-mcp
 spec:
-  dependsOn:
-    - name: toolhive-config
   interval: 1h
   path: ./kubernetes/apps/ai/mcp/konflate-mcp/app
   postBuild:

--- a/kubernetes/apps/ai/toolhive/ks.yaml
+++ b/kubernetes/apps/ai/toolhive/ks.yaml
@@ -39,8 +39,6 @@ kind: Kustomization
 metadata:
   name: toolhive-config
 spec:
-  dependsOn:
-    - name: toolhive-operator
   interval: 1h
   path: ./kubernetes/apps/ai/toolhive/config
   postBuild:

--- a/kubernetes/apps/external-secrets/onepassword-connect/ks.yaml
+++ b/kubernetes/apps/external-secrets/onepassword-connect/ks.yaml
@@ -5,8 +5,6 @@ kind: Kustomization
 metadata:
   name: onepassword-connect
 spec:
-  dependsOn:
-    - name: external-secrets
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/kubernetes/apps/kopiur-system/kopiur/ks.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/ks.yaml
@@ -21,8 +21,6 @@ kind: Kustomization
 metadata:
   name: kopiur-repositories
 spec:
-  dependsOn:
-    - name: kopiur
   interval: 1h
   path: ./kubernetes/apps/kopiur-system/kopiur/repository
   postBuild:

--- a/kubernetes/apps/network/envoy-gateway/ks.yaml
+++ b/kubernetes/apps/network/envoy-gateway/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: envoy-gateway
 spec:
-  dependsOn:
-    - name: cert-manager
-      namespace: cert-manager
   interval: 1h
   path: ./kubernetes/apps/network/envoy-gateway/app
   postBuild:

--- a/kubernetes/apps/observability/grafana/ks.yaml
+++ b/kubernetes/apps/observability/grafana/ks.yaml
@@ -21,8 +21,6 @@ kind: Kustomization
 metadata:
   name: grafana-instance
 spec:
-  dependsOn:
-    - name: grafana
   interval: 1h
   path: ./kubernetes/apps/observability/grafana/instance
   postBuild:
@@ -43,8 +41,6 @@ kind: Kustomization
 metadata:
   name: grafana-dashboards
 spec:
-  dependsOn:
-    - name: grafana-instance
   interval: 1h
   path: ./kubernetes/apps/observability/grafana/dashboards
   postBuild:

--- a/kubernetes/apps/observability/silence-operator/ks.yaml
+++ b/kubernetes/apps/observability/silence-operator/ks.yaml
@@ -21,8 +21,6 @@ kind: Kustomization
 metadata:
   name: silence-operator-silences
 spec:
-  dependsOn:
-    - name: silence-operator
   interval: 1h
   path: ./kubernetes/apps/observability/silence-operator/silences
   prune: true

--- a/kubernetes/apps/observability/victoria-logs/ks.yaml
+++ b/kubernetes/apps/observability/victoria-logs/ks.yaml
@@ -25,8 +25,6 @@ kind: Kustomization
 metadata:
   name: victoria-logs-collector
 spec:
-  dependsOn:
-    - name: victoria-logs
   interval: 1h
   path: ./kubernetes/apps/observability/victoria-logs/collector
   prune: true

--- a/kubernetes/apps/rook-ceph/ceph-csi-drivers/ks.yaml
+++ b/kubernetes/apps/rook-ceph/ceph-csi-drivers/ks.yaml
@@ -5,8 +5,6 @@ kind: Kustomization
 metadata:
   name: ceph-csi-drivers
 spec:
-  dependsOn:
-    - name: rook-ceph
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -22,7 +22,6 @@ metadata:
   name: rook-ceph-cluster
 spec:
   dependsOn:
-    - name: ceph-csi-drivers
     - name: rook-ceph
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/apps/system-upgrade/tuppr/ks.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/ks.yaml
@@ -21,8 +21,6 @@ kind: Kustomization
 metadata:
   name: tuppr-upgrades
 spec:
-  dependsOn:
-    - name: tuppr
   interval: 1h
   path: ./kubernetes/apps/system-upgrade/tuppr/upgrades
   prune: true


### PR DESCRIPTION
Second removal batch from the #1872 dependsOn audit: removes 20 edges whose absence produces only benign, retry-handled failures. For twelve of them the gated failure is real but apply-time — a missing CRD — and on the pinned stack that failure occurs before Helm stores a release, or in a direct kustomize apply, so it consumes no remediation and self-heals indefinitely. Each removal was established per edge by source and render analysis of the pinned charts and controllers, adversarially reviewed.

* Direct-CR dependents (12): kopiur-repositories → kopiur, tuppr-upgrades → tuppr, silence-operator-silences → silence-operator, onepassword-connect → external-secrets, envoy-gateway → cert-manager, toolhive-config → toolhive-operator, and the five MCP Kustomizations → toolhive-config. These apply their CRs directly through kustomize-controller: a missing CRD or a fail-closed admission rejection requeues at the retry interval, and the CRs sit inert until their controller appears. Kopiur's CRDs are bootstrap-installed (#1878); the rest ship with providers that reconcile independently.
* actions-runner-controller-runners → actions-runner-controller and → openebs: the runners chart renders no waitable workload (the listener is controller-created), controller discovery is explicitly configured, and runner storage is claimed at job time.
* Runtime-target edges: grafana-mcp → grafana-instance (non-waiting MCPServer Kustomization, actuated by the ToolHive controller), victoria-logs-collector → victoria-logs (push sink with disk buffering), litellm → dragonfly-operator (the pinned LiteLLM source tolerates an absent Redis at startup and reports Ready).
* Grafana pair: grafana-instance → grafana and grafana-dashboards → grafana-instance — direct CRs with bootstrap-installed CRDs; the operator requeues until its targets exist.
* Rook internal pair: rook-ceph-cluster → ceph-csi-drivers (no CRD, webhook or creation-ordering relationship crosses it) and ceph-csi-drivers → rook-ceph (the drivers chart renders only inert CRs and RBAC; a missing `csi.ceph.io` CRD fails before Helm stores a release and retries indefinitely).

Retained, per the same analysis: toolhive-operator → toolhive-operator-crds (the operator exits during synchronous field-index registration without its CRDs — a stored-release wait failure with bounded remediation) and rook-ceph-cluster → rook-ceph (the enabled toolbox cannot become Ready without operator-created inputs). The two GPU edges stay: plex and drm-exporter both carry DRA resource claims and cannot schedule without the driver — the same stored-release timeout path. Hermes's four edges, kromgo → kube-prometheus-stack and flux-instance → flux-operator are held pending startup tests in #1872's disposable-cluster run.

Validation: formatting and baseline rendering passed; all 78 Kustomizations Ready before the change. Post-merge convergence check per #1872.

No runtime effect on the live cluster; only reconcile gating changes.

