### PR TITLE
refactor(flux): reinstate family dependsOn edges, drop remaining availability edges

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
@@ -21,6 +21,8 @@ kind: Kustomization
 metadata:
   name: actions-runner-controller-runners
 spec:
+  dependsOn:
+    - name: actions-runner-controller
   interval: 1h
   path: ./kubernetes/apps/actions-runner-system/actions-runner-controller/runners
   prune: true

--- a/kubernetes/apps/ai/hermes/ks.yaml
+++ b/kubernetes/apps/ai/hermes/ks.yaml
@@ -5,11 +5,6 @@ kind: Kustomization
 metadata:
   name: hermes
 spec:
-  dependsOn:
-    - name: toolhive-config
-    - name: litellm
-    - name: context7-mcp
-    - name: konflate-mcp
   interval: 1h
   path: ./kubernetes/apps/ai/hermes/app
   postBuild:

--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   components:
     - ../../../../components/dragonfly
+  dependsOn:
+    - name: dragonfly-operator
+      namespace: database
   interval: 1h
   path: ./kubernetes/apps/ai/litellm/app
   postBuild:

--- a/kubernetes/apps/ai/mcp/context7-mcp/ks.yaml
+++ b/kubernetes/apps/ai/mcp/context7-mcp/ks.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 metadata:
   name: context7-mcp
 spec:
+  dependsOn:
+    - name: toolhive-config
   interval: 1h
   path: ./kubernetes/apps/ai/mcp/context7-mcp/app
   prune: true

--- a/kubernetes/apps/ai/mcp/flux-mcp/ks.yaml
+++ b/kubernetes/apps/ai/mcp/flux-mcp/ks.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 metadata:
   name: flux-mcp
 spec:
+  dependsOn:
+    - name: toolhive-config
   interval: 1h
   path: ./kubernetes/apps/ai/mcp/flux-mcp/app
   prune: true

--- a/kubernetes/apps/ai/mcp/github-mcp/ks.yaml
+++ b/kubernetes/apps/ai/mcp/github-mcp/ks.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 metadata:
   name: github-mcp
 spec:
+  dependsOn:
+    - name: toolhive-config
   interval: 1h
   path: ./kubernetes/apps/ai/mcp/github-mcp/app
   prune: true

--- a/kubernetes/apps/ai/mcp/grafana-mcp/ks.yaml
+++ b/kubernetes/apps/ai/mcp/grafana-mcp/ks.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 metadata:
   name: grafana-mcp
 spec:
+  dependsOn:
+    - name: toolhive-config
   interval: 1h
   path: ./kubernetes/apps/ai/mcp/grafana-mcp/app
   prune: true

--- a/kubernetes/apps/ai/mcp/konflate-mcp/ks.yaml
+++ b/kubernetes/apps/ai/mcp/konflate-mcp/ks.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 metadata:
   name: konflate-mcp
 spec:
+  dependsOn:
+    - name: toolhive-config
   interval: 1h
   path: ./kubernetes/apps/ai/mcp/konflate-mcp/app
   postBuild:

--- a/kubernetes/apps/ai/toolhive/ks.yaml
+++ b/kubernetes/apps/ai/toolhive/ks.yaml
@@ -39,6 +39,8 @@ kind: Kustomization
 metadata:
   name: toolhive-config
 spec:
+  dependsOn:
+    - name: toolhive-operator
   interval: 1h
   path: ./kubernetes/apps/ai/toolhive/config
   postBuild:

--- a/kubernetes/apps/external-secrets/onepassword-connect/ks.yaml
+++ b/kubernetes/apps/external-secrets/onepassword-connect/ks.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 metadata:
   name: onepassword-connect
 spec:
+  dependsOn:
+    - name: external-secrets
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/kubernetes/apps/kopiur-system/kopiur/ks.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/ks.yaml
@@ -21,6 +21,8 @@ kind: Kustomization
 metadata:
   name: kopiur-repositories
 spec:
+  dependsOn:
+    - name: kopiur
   interval: 1h
   path: ./kubernetes/apps/kopiur-system/kopiur/repository
   postBuild:

--- a/kubernetes/apps/network/envoy-gateway/ks.yaml
+++ b/kubernetes/apps/network/envoy-gateway/ks.yaml
@@ -5,6 +5,9 @@ kind: Kustomization
 metadata:
   name: envoy-gateway
 spec:
+  dependsOn:
+    - name: cert-manager
+      namespace: cert-manager
   interval: 1h
   path: ./kubernetes/apps/network/envoy-gateway/app
   postBuild:

--- a/kubernetes/apps/observability/grafana/ks.yaml
+++ b/kubernetes/apps/observability/grafana/ks.yaml
@@ -21,6 +21,8 @@ kind: Kustomization
 metadata:
   name: grafana-instance
 spec:
+  dependsOn:
+    - name: grafana
   interval: 1h
   path: ./kubernetes/apps/observability/grafana/instance
   postBuild:
@@ -41,6 +43,8 @@ kind: Kustomization
 metadata:
   name: grafana-dashboards
 spec:
+  dependsOn:
+    - name: grafana-instance
   interval: 1h
   path: ./kubernetes/apps/observability/grafana/dashboards
   postBuild:

--- a/kubernetes/apps/observability/kromgo/ks.yaml
+++ b/kubernetes/apps/observability/kromgo/ks.yaml
@@ -5,8 +5,6 @@ kind: Kustomization
 metadata:
   name: kromgo
 spec:
-  dependsOn:
-    - name: kube-prometheus-stack
   interval: 1h
   path: ./kubernetes/apps/observability/kromgo/app
   postBuild:

--- a/kubernetes/apps/observability/silence-operator/ks.yaml
+++ b/kubernetes/apps/observability/silence-operator/ks.yaml
@@ -21,6 +21,8 @@ kind: Kustomization
 metadata:
   name: silence-operator-silences
 spec:
+  dependsOn:
+    - name: silence-operator
   interval: 1h
   path: ./kubernetes/apps/observability/silence-operator/silences
   prune: true

--- a/kubernetes/apps/rook-ceph/ceph-csi-drivers/ks.yaml
+++ b/kubernetes/apps/rook-ceph/ceph-csi-drivers/ks.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 metadata:
   name: ceph-csi-drivers
 spec:
+  dependsOn:
+    - name: rook-ceph
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/kubernetes/apps/system-upgrade/tuppr/ks.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/ks.yaml
@@ -21,6 +21,8 @@ kind: Kustomization
 metadata:
   name: tuppr-upgrades
 spec:
+  dependsOn:
+    - name: tuppr
   interval: 1h
   path: ./kubernetes/apps/system-upgrade/tuppr/upgrades
   prune: true


### PR DESCRIPTION
Adopts a simpler dependsOn doctrine to close out the #1872 audit, trading proven minimality for a rule that survives controller upgrades and needs no per-edge analysis: each member of an operator family depends on the adjacent rung of its family's ladder; availability-gating edges are removed; a demonstrated stored-release failure earns an exception.

- Reinstates 16 family edges removed by #1884. The analysis behind #1884 stands — most of these are provably redundant on the pinned controllers — but that proof rests on version-pinned behaviour; the reinstated edges cost nothing, keep the graph legible, and hold without it.
- Removes the last availability edges: hermes → toolhive-config, litellm, context7-mcp, konflate-mcp, and kromgo → kube-prometheus-stack. Their startup behaviour under an absent backend was never tested; removal accepts the same bootstrap risk already accepted for the #1877 batch, recorded in #1872.
- rook-ceph-cluster → ceph-csi-drivers stays removed: nothing apply-time crosses it, so it is availability-shaped even under the new rule.
- The two DRA GPU edges stay as the doctrine's documented exception.

Final graph: 21 edges — 19 family, 2 exception; principles and classification in #1872.

Validation: formatting and baseline rendering passed. Reinstated edges mean those dependents again wait for their provider before reconciling — intended, family-internal coupling only. No runtime effect on the live cluster; post-merge convergence check per #1872.
