### PR TITLE
refactor(flux): remove consumer dependsOn edges, bootstrap dragonfly CRDs

### DIFF
--- a/bootstrap/helmfile/crds.yaml
+++ b/bootstrap/helmfile/crds.yaml
@@ -24,6 +24,9 @@ releases:
   - name: cloudflare-dns
     namespace: network
 
+  - name: dragonfly-operator
+    namespace: database
+
   - name: envoy-gateway
     namespace: network
 

--- a/docs/guides/cluster-model.md
+++ b/docs/guides/cluster-model.md
@@ -47,12 +47,15 @@ When adding an app, apply the rule in this order:
 - One exception class by rule: operator families. Each member depends on
   the adjacent rung of its family's ladder — instance on operator, operator
   on its CRD chart, content on instance — whether or not bootstrap also
-  installs the CRDs. These edges are declared intent, not proven necessity;
-  some are provably redundant on current controller versions, and that is
-  accepted.
+  installs the CRDs. A dependent is family when its primary resource is an
+  instance of the dependency's API; a workload that applies another
+  component's CR incidentally is a consumer, not family, and gets no edge.
+  Family edges are declared intent, not proven necessity; some are provably
+  redundant on current controller versions, and that is accepted.
 - Cross-family CRD consumers get no edge; their CRDs are installed
-  out-of-band at bootstrap (`bootstrap/helmfile/crds.yaml`), and Flux/Helm
-  keep CRD upgrade ownership either way.
+  out-of-band at bootstrap (`bootstrap/helmfile/crds.yaml`, or a
+  whole-product install in the bootstrap apps phase), and Flux/Helm keep
+  CRD upgrade ownership either way.
 - One exception class by evidence: an availability-shaped edge is kept
   where its absence demonstrably produces a stored-release Helm failure
   with bounded remediation. Currently two: `plex` and `drm-exporter` on

--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   components:
     - ../../../../components/dragonfly
-  dependsOn:
-    - name: dragonfly-operator
-      namespace: database
   interval: 1h
   path: ./kubernetes/apps/ai/litellm/app
   postBuild:

--- a/kubernetes/apps/external-secrets/onepassword-connect/ks.yaml
+++ b/kubernetes/apps/external-secrets/onepassword-connect/ks.yaml
@@ -5,8 +5,6 @@ kind: Kustomization
 metadata:
   name: onepassword-connect
 spec:
-  dependsOn:
-    - name: external-secrets
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/kubernetes/apps/network/envoy-gateway/ks.yaml
+++ b/kubernetes/apps/network/envoy-gateway/ks.yaml
@@ -5,9 +5,6 @@ kind: Kustomization
 metadata:
   name: envoy-gateway
 spec:
-  dependsOn:
-    - name: cert-manager
-      namespace: cert-manager
   interval: 1h
   path: ./kubernetes/apps/network/envoy-gateway/app
   postBuild:


### PR DESCRIPTION
Completes the #1872 doctrine's consumer-edge cleanup: removes the three consumer edges — 18 edges remain, operator-family rungs plus the two documented DRA exceptions. (The doctrine review later showed the rule text at this point still could not uniquely derive the graph; #1888 simplified it to one pattern.)

- litellm → dragonfly-operator, envoy-gateway → cert-manager, onepassword-connect → external-secrets: in each, the dependent's primary workload is its own and its dependency-crossing CRs are incidental (a Dragonfly; a Certificate; a ClusterSecretStore plus two ExternalSecrets, whose initial target Secrets bootstrap creates statically before the Connect chart starts). cert-manager and external-secrets are installed whole in the bootstrap apps phase before Flux starts, so their CRDs always exist; litellm tolerates an absent Redis at startup and reports Ready (source-level demonstration, per the #1872 acceptance standard).
- Adds dragonfly-operator to `bootstrap/helmfile/crds.yaml` so the Dragonfly CRD (`dragonflies.dragonflydb.io`, verified through the exact bootstrap render pipeline) exists before Flux — closing the gap the litellm removal would otherwise open.
- `cluster-model.md`: the family rule gains the primary-vs-incidental test that distinguishes these edges from family rungs, and the cross-family bullet now names both bootstrap mechanisms (`crds.yaml` and whole-product apps-phase installs) — the wording gap that let these three edges pass as rule-derived.

Validation: formatting and baseline rendering passed; the full bootstrap CRD render includes the new entry. No runtime effect on the live cluster; post-merge convergence check per #1872.

