### PR TITLE
docs(operations): correct descheduler rationale and record rollout lessons

### DIFF
--- a/docs/guides/cluster-model.md
+++ b/docs/guides/cluster-model.md
@@ -1,11 +1,15 @@
 # Cluster Model
 
-**When to use:** Flux reconcile path, dependsOn, reconciliation ordering, secrets, ExternalSecret, SOPS, `cluster-secrets`, substitution, backups, Kopiur, PVC, UID/GID, mover identity, RWO, replicas, scheduling, descheduler policy, node placement and rebalancing, rolling Talos upgrades, service networking, LoadBalancer addresses, BGP, L2 announcements, high-risk surfaces.
+**When to use:** Flux reconcile path, dependsOn, reconciliation ordering, secrets, ExternalSecret, SOPS, `cluster-secrets`, substitution, backups, Kopiur, PVC, UID/GID, mover identity, RWO, replicas, service networking, LoadBalancer addresses, BGP, L2 announcements, high-risk surfaces.
 
 How a change reaches the cluster, how secrets and state get there, and which
 surfaces are high-risk to touch. For repository layout and app file shape see
 [`app-pattern.md`](app-pattern.md); for validation commands see
-[`validation.md`](validation.md).
+[`validation.md`](validation.md); for scheduling, descheduler policy, node
+placement and rebalancing, and rolling upgrades see
+[`../operations/node-upgrades.md`](../operations/node-upgrades.md). Node
+firmware, boot, and hang-at-reboot recovery notes are local and untracked:
+`.private/node-firmware-and-boot.md`.
 
 ## How a merged change reaches the cluster
 
@@ -156,19 +160,6 @@ its SQLite database allows one writer, so it pins `replicas: 1` with
 `strategy: Recreate`, routes writes through the one API pod, and must never
 be scaled. That constraint comes from the app, not from RWO or any
 cluster-wide rule.
-
-## Scheduling and rebalancing
-
-The descheduler's `LowNodeUtilization` strategy uses actual CPU and memory
-utilization plus pod count, while the scheduler's `NodeResourcesFit` scoring
-uses requested resources. Where it has proven its value so far is convergence
-after rolling Talos upgrades. Drains concentrate workloads on the surviving
-nodes; once a rebooted node returns, the strategy evicts eligible pods so the
-scheduler can repopulate it. The observed post-upgrade burst demonstrated
-useful convergence, and similar bursts are expected then. Sustained evictions
-outside an upgrade or recovery event may indicate a policy loop. Changes to
-descheduler policy should preserve equivalent post-upgrade convergence or
-explicitly replace it.
 
 ## Service networking
 

--- a/docs/operations/node-upgrades.md
+++ b/docs/operations/node-upgrades.md
@@ -1,8 +1,11 @@
 # Node Upgrades
 
 How Talos and Kubernetes version bumps roll through the nodes, what a healthy
-rollout looks like, and which side effects are expected rather than incidents.
-Baseline observations are from the 2026-08-06 Talos 1.13.7 → 1.13.8 rollout.
+rollout looks like, which side effects are expected rather than incidents,
+how workloads respread afterwards (scheduling, descheduler policy), and what
+persists when a rollout fails mid-way. Baseline observations are from the
+2026-08-06 Talos 1.13.7 → 1.13.8 rollout and the 1.13.8 → 1.13.9 rollout
+(2026-08-21 to 08-27), which a node firmware hang split across six days.
 
 ## How a rollout runs
 
@@ -38,20 +41,66 @@ time.
 The last node upgraded ends the rollout nearly empty — everything drained off
 it has been rescheduled onto the earlier nodes, and nothing moves back on its
 own. The descheduler's `LowNodeUtilization` profile
-(`kubernetes/apps/kube-system/descheduler/`) is what restores balance: it
-compares actual usage from metrics against per-dimension thresholds and
-evicts up to five pods per node per five-minute cycle from overutilized
-nodes. In this cluster CPU and memory sit far below the 50% targets, so the
-pod-count dimension (target 45% of pod capacity) is what actually drives
-rebalancing after a rollout.
+(`kubernetes/apps/kube-system/descheduler/`) restores balance on the same
+signal the scheduler places by: requested CPU and memory, as deviation bands
+of ±10 points around the fleet mean. A node below the lower band on every
+resource is a target; each node above the upper band on any resource sheds up
+to five pods per five-minute cycle. Because eviction and replacement
+placement optimise the same quantity, the post-rollout burst converges
+rather than looping: a workload may hop more than once while the fleet
+re-levels, but each eviction hits a fresh replacement pod, and the burst
+ends once every node is inside the bands.
+
+Rebalancing toward a returning node cannot begin while tuppr's cordon holds:
+the descheduler never targets an unschedulable node, and tuppr uncordons
+only once the node's health checks pass. Its
+`tuppr.home-operations.com/outdated` taint is `PreferNoSchedule` — invisible
+to the descheduler, but scored against by the scheduler, which biases
+replacement placement away from not-yet-upgraded nodes. An "underutilized
+node, zero evictions" reading mid-rollout is sequencing, not a fault.
 
 Convergence is deliberately gradual — expect balance within a few cycles, not
-immediately. Verify with pods-per-node counts rather than assuming:
+immediately. Verify with the descheduler's own log (node classifications and
+`totalEvicted`), not pods-per-node counts: pod count is not part of the
+policy, so uneven counts with every node inside the request bands is the
+policy working, not failing.
 
-```sh
-kubectl get pods -A -o wide --field-selector=status.phase=Running
-```
+The policy balances on requests deliberately. Its predecessor balanced on
+actual utilisation and pod count — signals the scheduler does not place by —
+and evicted the same pods from the same node every five minutes for over a
+day while the scheduler put every replacement straight back (#1805). A future
+policy change should keep eviction and placement on one signal or expect the
+same loop.
 
-Balanced per the stated thresholds does not mean numerically equal: the
-descheduler stops evicting once no node exceeds the target thresholds, so a
-residual skew inside the target band is the policy working, not failing.
+## When a node stays down
+
+A node that hangs at its upgrade reboot leaves the rollout in a stable but
+non-obvious state. Observed across the six-day 2026-08-21 outage:
+
+- tuppr retries the node's upgrade job, marks the `TalosUpgrade` `Failed`,
+  and stops; the remaining nodes are not touched. The dead node keeps its
+  cordon and `outdated` taint — Node objects are not Flux-managed, so both
+  persist until removed. Recovery order: power-cycle the node (the installer
+  finishes before the reboot, so it boots the target version), uncordon it,
+  wait for Ceph `HEALTH_OK`, then annotate the CR with
+  `tuppr.home-operations.com/reset="$(date)"`. tuppr re-evaluates, skips
+  already-upgraded nodes, clears their taints, and finishes the rollout.
+- The cluster runs without failure tolerance meanwhile (etcd 2/3, Ceph
+  `min_size` 2 with one OSD down): hold storage changes and anything that
+  drains a node until recovery.
+- Any HelmRelease whose chart ships a DaemonSet wedges if upgraded during
+  the outage: the DaemonSet counts the dead node in its desired set, helm's
+  health wait cannot complete, and the release lands in `pending-rollback`
+  with Flux retrying. Harmless and self-resolving on node return; merging
+  bumps to DaemonSet-shipping charts during a known outage queues them
+  behind the wedge.
+- Rook probes mon failover (recurring short-lived `mon-canary` pods that
+  find no placement and are cleaned up) and refuses `ok-to-stop` while
+  redundancy is degraded. Both end on node return, after which deferred OSD
+  deployment updates roll one at a time — expected churn, not a fault.
+- A drain that evicts the kopiur controller mid-operation produces a burst
+  of retried snapshots and UUID-named `snapdel` jobs. The cockpit
+  failed-jobs panel counts pod-level retries; judge backup health by
+  Snapshot phases, not that panel.
+- The descheduler idles with no under-band target available — correct
+  behaviour, not a stuck controller.


### PR DESCRIPTION
Corrects the descheduler rationale the docs carried and moves scheduling and rolling-upgrade material into `docs/operations/node-upgrades.md`, which now owns it.

- cluster-model.md credited the old actual-utilisation-plus-pod-count descheduler policy with post-upgrade convergence. It was an eviction loop: roughly 980 evictions of the same pods from one node over 26 hours, each replacement placed straight back, fixed by the request-band policy in #1805. Steady-state evictions have been zero since, and the 2026-08-27 post-rollout burst tapered to zero within seven cycles.
- node-upgrades.md gains the request-band policy mechanics, how to verify convergence from the descheduler's own log rather than pods-per-node counts, and a section on what persists when a rollout fails mid-way: `Failed` CR semantics, cordon and taint persistence, the reset annotation, and expected side effects while a node is down.
- One correction from checking sources rather than release notes: mid-rollout rebalancing is gated by tuppr's cordon, not its outdated taint — the taint is `PreferNoSchedule`, which the descheduler ignores and the scheduler only scores against.

Unit-level firmware and boot detail stays in local notes, routed from cluster-model's opening paragraph.