### PR TITLE
docs(operations): add observability note

### DIFF
--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -3,7 +3,9 @@
 **When to use:** What to run before merging, render, flate, Konflate, kubeconform, image diff, bypass merge, CI boundaries, `just` versus `mise`, release notes, Renovate PR Review bot, firing alerts, Alertmanager, silences.
 
 Use the smallest validation set that matches the change. What to run, what each
-check actually proves, and where the tooling boundaries sit.
+check actually proves, and where the tooling boundaries sit. For querying
+logs, metrics, and dashboards while investigating live behaviour, see
+[`../operations/observability.md`](../operations/observability.md).
 
 ## Commands
 

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -1,0 +1,58 @@
+# Observability
+
+Where to look when investigating cluster behaviour, and how to query each
+store from a terminal: logs in VictoriaLogs, metrics in Prometheus,
+dashboards in Grafana. Alert-interpretation caveats are in
+[`../guides/validation.md`](../guides/validation.md).
+
+## Logs: VictoriaLogs
+
+Every pod's stdout and stderr is shipped to VictoriaLogs (service
+`victoria-logs` in `observability`, HTTP port 9428), so pod log rotation and
+pod replacement do not lose history — a controller's behaviour from weeks
+ago is still queryable long after `kubectl logs` has nothing. Collection
+began 2026-08-07; nothing earlier exists, and the live window should be
+checked before assuming old events are still held.
+
+Query with LogsQL over the HTTP API through a short-lived port-forward:
+
+```sh
+kubectl -n observability port-forward svc/victoria-logs 9428:9428 &
+curl -s http://localhost:9428/select/logsql/query \
+  --data-urlencode 'query=kubernetes.pod_name:~"descheduler" AND "Evicted"' \
+  --data-urlencode 'start=2026-08-27T00:00:00Z' \
+  --data-urlencode 'end=2026-08-28T00:00:00Z' \
+  --data-urlencode 'limit=10'
+```
+
+Useful structured fields: `kubernetes.pod_namespace`, `kubernetes.pod_name`,
+`kubernetes.container_name`, `kubernetes.pod_node_name`; the message is
+`_msg` and the timestamp `_time`. Aggregate with stats pipes — for example
+`| stats by (_time:1d) count() n` for a per-day histogram, or
+`| stats min(_time) first, max(_time) last, count() n` to bound when
+something started and stopped. Tuppr's per-node upgrade jobs ship here too,
+including the installer completion and sd-boot probe lines that
+[`node-upgrades.md`](node-upgrades.md) relies on.
+
+## Metrics: Prometheus
+
+Upstream Prometheus via kube-prometheus-stack (service
+`kube-prometheus-stack-prometheus` in `observability`, port 9090), with a
+14-day retention window — request audits and sizing questions reaching
+further back need another source. Alertmanager is
+`kube-prometheus-stack-alertmanager` on port 9093.
+
+## Dashboards: Grafana
+
+Grafana is operator-managed (`grafana-service`, port 3000); dashboards are
+declared in `kubernetes/apps/observability/grafana/dashboards/`.
+`home-ops-cockpit` is the operational overview. Known caveat: its
+failed-jobs panel counts pod-level retries, so a burst there is not by
+itself a backup failure — judge backup health by Kopiur Snapshot phases
+([`node-upgrades.md`](node-upgrades.md)).
+
+## Triage order
+
+The cockpit dashboard for the shape of the problem; firing alerts next,
+read against validation.md's caveats; then VictoriaLogs for the implicated
+pods' history; `kubectl describe` and events for current object state.


### PR DESCRIPTION
Adds the operations note for the observability stack: querying VictoriaLogs with LogsQL through a port-forward (structured fields, stats pipes, the 2026-08-07 collection start), the Prometheus and Alertmanager services with the 14-day metrics window, Grafana dashboard locations with the cockpit failed-jobs caveat, and a triage order. Everything in it was verified live during the 2026-08-30 node-rollout docs review, which had to rediscover the query surface by probing — this note is what that session lacked. validation.md's opening paragraph routes to it.