### PR TITLE
feat(flux): pilot cosign verification on three chart sources

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -11,6 +11,8 @@ _.file = ["{{config_root}}/.secrets.env"]
 [tools]
 actionlint = "1.7.12"
 age = "1.3.2"
+# Chart-source signature re-validation (ADR-0003); run via `mise exec -- cosign`.
+cosign = "3.1.2"
 flux2 = "2.9.4"
 "github:home-operations/flate" = "v0.6.1"
 helm = "4.2.4"

--- a/kubernetes/apps/default/tautulli/app/ocirepository.yaml
+++ b/kubernetes/apps/default/tautulli/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 5.1.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/bjw-s-labs/helm-charts/\\.github/workflows/chart-release-steps\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/default/thelounge/app/ocirepository.yaml
+++ b/kubernetes/apps/default/thelounge/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 5.1.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/bjw-s-labs/helm-charts/\\.github/workflows/chart-release-steps\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/network/echo/app/ocirepository.yaml
+++ b/kubernetes/apps/network/echo/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 0.2.4
   url: oci://ghcr.io/home-operations/charts/echo
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/home-operations/echo/\\.github/workflows/release\\.yaml@refs/tags/[0-9]+\\.[0-9]+\\.[0-9]+$"


### PR DESCRIPTION
Pilot phase of #1894, implementing ADR-0003.

Three low-value chart sources gain identity-bound cosign verification, covering both signature formats in use:

- thelounge and tautulli — app-template 5.1.0, legacy `.sig` signatures, reusable-workflow custody.
- echo — cosign v3 bundle, direct upstream workflow identity.

Each identity was re-validated today against the currently pinned artifact: the certificate was read, the issuer and subject recorded, and `cosign verify` passed end to end under the same anchored regexes the manifests now carry. The observed issuer and subject for each source are recorded per source in #1894, giving later phases a checkable baseline; the original 2026-08-07 audit lives in private notes. cosign 3.1.2 is pinned in mise so later phases can repeat the re-validation.

Validation: oxfmt clean, `flate test all` 207 passed, kustomize renders keep the regex escaping intact, and a server dry-run accepted all three changed OCIRepositories. The dry-run proves the schema is accepted, not that verification works: the pilot gate is post-merge — `SourceVerified=True` on all three sources, with echo confirming the deployed source-controller accepts v3 bundles — before any extension.
