### PR TITLE
feat(konflate): serve MCP in-cluster only

### DIFF
--- a/docs/operations/public-surfaces.md
+++ b/docs/operations/public-surfaces.md
@@ -17,15 +17,16 @@ that exposes it.
 | Seerr                       | Household members, plus probe and API clients                      | Yes                                                                          | Yes — approvals drive the download stack                                   | Its own sign-in, which is delegated to Plex accounts                    |
 | Konflate — read APIs and UI | People and CI                                                      | Analysis of an already-public repository; its value is as CI review evidence | No                                                                         | None                                                                    |
 | Konflate — webhook          | GitHub's webhook delivery                                          | Nothing in its responses                                                     | Yes — a valid call triggers work                                           | Cryptographic signature check on every request                          |
-| Konflate — MCP              | One in-cluster client                                              | Same data as the read APIs                                                   | No                                                                         | None                                                                    |
 | Flux webhook receiver       | GitHub's webhook delivery                                          | Nothing in its responses                                                     | Yes — a valid call makes the cluster pull and apply the repo's main branch | Cryptographic signature check, limited to specific events and resources |
 | Gatus status page           | People, plus the page's own scripts and a metrics endpoint         | The list of monitored services and their uptime history                      | No                                                                         | None                                                                    |
 | Kromgo badges               | GitHub's image proxy and other fetchers                            | Cluster version and count metadata                                           | No                                                                         | Only pre-defined queries run, and only the badge path is routed         |
 | echo                        | An automated reachability monitor                                  | Pod and node identifiers                                                     | No                                                                         | Command execution disabled                                              |
 | qBittorrent peer port       | BitTorrent peers                                                   | None served; the pod can write to download storage                           | Yes                                                                        | The protocol implementation itself                                      |
 
-Konflate is listed three times deliberately: its paths have different
-consumers and different tolerable controls, and treating the hostname as one
-surface is what produces controls that break CI. "Surface" and "route" are
-different units — Konflate is one route and three surfaces — so this
-register counts neither.
+Konflate is listed twice deliberately: its paths have different consumers
+and different tolerable controls, and treating the hostname as one surface
+is what produces controls that break CI. "Surface" and "route" are different
+units — Konflate is one route and two public surfaces — so this register
+counts neither. Its MCP endpoint is no longer a public surface: the external
+route answers 404 on that path, and its one client consumes the in-cluster
+service directly.

--- a/kubernetes/apps/ai/mcp/konflate-mcp/app/mcpserverentry.yaml
+++ b/kubernetes/apps/ai/mcp/konflate-mcp/app/mcpserverentry.yaml
@@ -5,7 +5,8 @@ kind: MCPServerEntry
 metadata:
   name: konflate
 spec:
-  remoteUrl: https://konflate.${SECRET_DOMAIN}/mcp
+  remoteUrl: http://konflate.flux-system.svc.cluster.local:8080/mcp
+  allowPrivateEndpoint: true
   transport: streamable-http
   groupRef:
     name: mcp-tools

--- a/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
@@ -29,6 +29,21 @@ spec:
           namespace: network
       hostnames:
         - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+      # The MCP endpoint's only consumer is in-cluster (ADR-0004); answer it
+      # with 404 externally instead of forwarding to the backend. Prepended
+      # before the default catch-all rule, and /mcp is the longer path prefix,
+      # so it takes precedence for GET, POST, and DELETE alike.
+      additionalRules:
+        - filters:
+            - type: ExtensionRef
+              extensionRef:
+                group: gateway.envoyproxy.io
+                kind: HTTPRouteFilter
+                name: konflate-mcp-not-found
+          matches:
+            - path:
+                type: PathPrefix
+                value: /mcp
     monitoring:
       serviceMonitor:
         enabled: true

--- a/kubernetes/apps/flux-system/konflate/app/httproutefilter.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/httproutefilter.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.envoyproxy.io/httproutefilter_v1alpha1.json
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: HTTPRouteFilter
+metadata:
+  name: konflate-mcp-not-found
+spec:
+  directResponse:
+    statusCode: 404

--- a/kubernetes/apps/flux-system/konflate/app/kustomization.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./httproutefilter.yaml
   - ./ocirepository.yaml


### PR DESCRIPTION
Retargets the toolhive MCPServerEntry at Konflate's in-cluster Service and answers `/mcp` with 404 on the external route, as the paired change ADR-0004 calls for — the client retarget alone removes no exposure, and a route change alone breaks the workbench. The remaining consumers of the route are unchanged: the CI summary fetch, the UI and its assets, the websocket, and the signed webhook all stay on the catch-all rule, and the workbench is the endpoint's only wired client. `allowPrivateEndpoint: true` accompanies the retarget — toolhive's SSRF guard otherwise rejects cluster-local URLs. Removes the Konflate MCP row from the public surface register. Tracked by #1233.

The two halves are independent Flux Kustomizations with no ordering edge between them — deliberately, per the reconciliation-ordering doctrine. One commit removes any durable split in Git; runtime convergence takes as long as the controllers behind each half take. Manifest and Helm-action failures alert through Flux; route and client behaviour are verified by the post-merge checks: `/mcp` answering 404 externally, the workbench listing tools over the internal URL.


