### PR TITLE
docs(agents): record enforcement ownership and routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,9 @@ This file is the canonical agent entrypoint and, among this repository's own
 documents, the authority on change control: where it and another document here
 disagree, this file wins. It adds to the global agent rules in
 `~/.config/agents/AGENTS.md` and does not relax them — those set a floor this
-file can raise and not lower.
+file can raise and not lower. Harness-specific enforcement — permission
+allowlists and hooks — is managed in the dotfiles layer, not here. A machine
+without that layer runs sessions on prose alone.
 
 `CLAUDE.md` beside it is a compatibility symlink to this file, because Claude
 Code reads that name and not `AGENTS.md`. Edit this file, never the link.
@@ -25,12 +27,13 @@ line; read only those whose triggers match the task at hand.
   boundaries, bypass merges.
 - `peers.md`: reference repository catalog and how to use it.
 - `pr-and-issue-writing.md`: issue bodies, pull request descriptions, and
-  comments. Read it before posting or editing any GitHub prose.
+  comments. Read it before drafting, reviewing, or posting any GitHub prose.
 
-`.agents/skills/` holds task recipes such as `add-app`. Load a skill only when
-performing that task. Load `maintenance-window` before planning or executing
-any window that stops workloads, deletes or recreates PVCs, or holds imperative
-cluster state across a merge.
+`.agents/skills/` holds harness-agnostic task recipes such as `add-app`;
+anything specific to a particular harness lives in the dotfiles layer, not
+here. Load a skill only when performing that task. Load `maintenance-window`
+before planning or executing any window that stops workloads, deletes or
+recreates PVCs, or holds imperative cluster state across a merge.
 
 ## Before Editing
 
@@ -146,10 +149,15 @@ so the rule is not "never use it" but "never let it be the only copy": other
 agents and other clients cannot read it, and guidance held by one assistant is
 guidance every other one ignores.
 
+Place content by who must act on it: authoring → guides, operating →
+operations notes, deciding → ADRs.
+
 - A prose, review, or issue-hygiene convention →
   `docs/guides/pr-and-issue-writing.md`.
 - A cluster, secret, or storage fact → `docs/guides/cluster-model.md`, or the
   relevant note under `docs/operations/`.
+- A decision among alternatives, with trade-offs accepted → an ADR under
+  `docs/adr/`.
 - A caveat about what a check does or does not prove →
   `docs/guides/validation.md`.
 - A peer-comparison scoping rule → `docs/guides/peers.md`.

--- a/docs/guides/pr-and-issue-writing.md
+++ b/docs/guides/pr-and-issue-writing.md
@@ -146,6 +146,10 @@ pull request. A retrospective comment on a merged pull request is acceptable
 and better than the alternative; write it as if it had always been there, with
 no trace of the recovery.
 
+While the guidance programme (#1768) runs, append a row to
+`.private/prose-evidence-log.md` when an artifact is signed off; the log's
+header carries the format.
+
 ## Public safety
 
 This repository is public. `AGENTS.md` lists what must never appear in public


### PR DESCRIPTION
Applies the #1912 layer decisions to the guidance tree, delivering #1913's five edits: the root file now states that harness-specific enforcement (permission allowlists, hooks) is dotfiles-managed and a machine without that layer runs sessions on prose alone; `.agents/skills/` is recorded as the harness-agnostic home; decisions route to ADRs under a named placement criterion (authoring → guides, operating → operations notes, deciding → ADRs); the GitHub-prose trigger covers drafting and reviewing, not only posting and editing; and the issue/PR guide gains the programme-scoped prose-log hook, to be removed when child 5/6 gives the log a permanent home.

No safety prose is removed or weakened; child 9 owns compression once children 7 and 8 verify their controls.

Validation: both files wrap at 80 columns (the three over-length lines predate this change), every routing reference resolves — `docs/adr/` exists with four ADRs — and lefthook's format-markdown pass ran clean at commit.
