### PR TITLE
docs(agents): add github-prose skill and two issue templates

### DIFF
--- a/.agents/skills/github-prose/SKILL.md
+++ b/.agents/skills/github-prose/SKILL.md
@@ -37,8 +37,8 @@ request bodies see [references/pr-shapes.md](references/pr-shapes.md).
 - Enumerate the open decisions and put them to the owner before drafting.
   Each decided question deletes more prose than any wording round, and
   hedging in a draft is usually an undecided question wearing a sentence.
-- Freeze the template and section structure with the owner. Contract
-  silence is a reportable gap, never implicit permission.
+- Freeze the template and section structure with the owner. A question the
+  contract does not answer is a gap to report, never permission to guess.
 - For a set of artifacts that reference each other, state the posting
   order in the draft header. Placeholders resolve by posting order: post
   for a number, substitute it, back-fill the referrer.
@@ -67,16 +67,12 @@ than hiding it.
   once. Corrections afterwards are edits in place.
 - Umbrella children get native sub-issue links at open time, and the
   children table stays the record.
-- Append a row to `.private/prose-evidence-log.md` at sign-off, per its
-  header rules.
 - Rename a generated branch to a descriptive slug before opening the
   pull request.
 
 ## 6. Maintain
 
-- The body is the record: tick boxes as work lands, correct wording that
-  has become false, fold conclusions in rather than appending them.
-- A follow-up that outlives its issue gets its own open issue or umbrella
-  row before the parent closes.
-- Corrections and retrospective additions read as if they had always been
-  there.
+Per the guide's body-is-the-record and re-homing rules: tick boxes as work
+lands, correct in place, re-home surviving follow-ups before the parent
+closes, and write retrospective additions as if they had always been
+there.

--- a/.agents/skills/github-prose/SKILL.md
+++ b/.agents/skills/github-prose/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: github-prose
+description: Lifecycle for drafting, reviewing, and posting GitHub prose — issues, pull request bodies, and ADRs — through the owner sign-off flow. Use when writing any of these, from artifact choice to post-merge maintenance.
+---
+
+# GitHub Prose
+
+The rules live in `docs/guides/pr-and-issue-writing.md` and `AGENTS.md`;
+this skill carries the process and defers to them. Where a line here and
+the guide disagree, the guide wins.
+
+## 1. Choose the artifact
+
+Check for an existing tracker before opening anything; extending it beats
+duplicating it.
+
+Choose by adoption event, audience, and amendment cost:
+
+- **ADR** (`docs/adr/`) records a standing decision: adopted by merge,
+  read later by people who never open issues, amended only by a further
+  pull request. Anything with checkboxes, phases, or per-item delivery
+  records is not an ADR — that state belongs in an issue that cites it.
+- **Issue** is where deciding and tracking happen: adopted by owner
+  sign-off, body cheaply editable, closed when its criteria hold.
+- **Operations note** (`docs/operations/`) is a living register consulted
+  while operating; it is maintained by the pull requests that change what
+  it registers.
+- Most small issues need no template: a paragraph of prose stating the
+  point and its closing condition.
+
+For issue shapes and template selection see
+[references/issue-shapes.md](references/issue-shapes.md); for pull
+request bodies see [references/pr-shapes.md](references/pr-shapes.md).
+
+## 2. Contract before drafting
+
+- Enumerate the open decisions and put them to the owner before drafting.
+  Each decided question deletes more prose than any wording round, and
+  hedging in a draft is usually an undecided question wearing a sentence.
+- Freeze the template and section structure with the owner. Contract
+  silence is a reportable gap, never implicit permission.
+- For a set of artifacts that reference each other, state the posting
+  order in the draft header. Placeholders resolve by posting order: post
+  for a number, substitute it, back-fill the referrer.
+
+## 3. Draft
+
+- One fact per clause, short sentences. Density and accuracy are
+  independent axes; a readable rewrite loses no claims.
+- Every number is verified by you, this session. Never inherit one.
+- State a mechanism's limit, not the universe's: "no X can Y" invites the
+  falsification it will get.
+- Define coined terms in place; every noun phrase must resolve within the
+  document.
+- The destination decides wrapping and style — see the guide, including
+  its public-safety checklist, before presenting anything.
+
+## 4. Review
+
+Apply [references/review-contract.md](references/review-contract.md).
+The owner may skip the review pass explicitly; record the skip rather
+than hiding it.
+
+## 5. Sign off and post
+
+- Present the draft in chat; post only after explicit sign-off, and only
+  once. Corrections afterwards are edits in place.
+- Umbrella children get native sub-issue links at open time, and the
+  children table stays the record.
+- Append a row to `.private/prose-evidence-log.md` at sign-off, per its
+  header rules.
+- Rename a generated branch to a descriptive slug before opening the
+  pull request.
+
+## 6. Maintain
+
+- The body is the record: tick boxes as work lands, correct wording that
+  has become false, fold conclusions in rather than appending them.
+- A follow-up that outlives its issue gets its own open issue or umbrella
+  row before the parent closes.
+- Corrections and retrospective additions read as if they had always been
+  there.

--- a/.agents/skills/github-prose/references/issue-shapes.md
+++ b/.agents/skills/github-prose/references/issue-shapes.md
@@ -1,0 +1,23 @@
+# Issue shapes
+
+Maps recurring issue shapes to their template in `.github/ISSUE_TEMPLATE/`
+and a merged exemplar. Templates are starting shapes: delete sections that
+do not apply, rename a heading when that makes its contents more accurate.
+Every exemplar below is local; read it before drafting the same shape.
+
+| Shape                      | Template                  | Exemplar    | Notes                                                                                 |
+| -------------------------- | ------------------------- | ----------- | ------------------------------------------------------------------------------------- |
+| Design proposal            | design-proposal           | #1912       | Decide among alternatives; body records the agreed design.                            |
+| Operational investigation  | operational-investigation | —           | Observation → diagnosis → correction, evidence-led.                                   |
+| Umbrella                   | umbrella                  | #1768       | Coordinates children; never implements. Sub-issue links at open time.                 |
+| Programme tracking         | tracking                  | #1872       | Doctrine and state for multi-PR work; principles as summary + pointer.                |
+| Decision-tracking stub     | tracking                  | #1233       | Principles and current-state sections deleted; adoption boxes tied to merges.         |
+| Audit findings             | audit-findings            | #1906       | Categories public, identities in `.private/`; findings feed named successors.         |
+| Small capture or follow-up | none                      | #1899–#1902 | One paragraph of prose with a closing condition; check for an existing tracker first. |
+| Decision checkpoint        | none                      | #1899       | Verdict-first, per-trigger bullets, dated next checkpoint carried in the title.       |
+
+Shape selection failures worth knowing: the #1233 body took four shape
+pivots because the artifact class was chosen after drafting instead of
+before — run the skill's step 1 first; and a one-round convergence can
+still ship a framing defect when the lead borrows another artifact's
+classification language, so restate the rule in this issue's own terms.

--- a/.agents/skills/github-prose/references/issue-shapes.md
+++ b/.agents/skills/github-prose/references/issue-shapes.md
@@ -1,9 +1,9 @@
 # Issue shapes
 
 Maps recurring issue shapes to their template in `.github/ISSUE_TEMPLATE/`
-and a merged exemplar. Templates are starting shapes: delete sections that
-do not apply, rename a heading when that makes its contents more accurate.
-Every exemplar below is local; read it before drafting the same shape.
+and a merged exemplar; the guide's Choosing a shape section owns the
+template descriptions. Every exemplar below is local; read it before
+drafting the same shape.
 
 | Shape                      | Template                  | Exemplar    | Notes                                                                                 |
 | -------------------------- | ------------------------- | ----------- | ------------------------------------------------------------------------------------- |
@@ -13,7 +13,7 @@ Every exemplar below is local; read it before drafting the same shape.
 | Programme tracking         | tracking                  | #1872       | Doctrine and state for multi-PR work; principles as summary + pointer.                |
 | Decision-tracking stub     | tracking                  | #1233       | Principles and current-state sections deleted; adoption boxes tied to merges.         |
 | Audit findings             | audit-findings            | #1906       | Categories public, identities in `.private/`; findings feed named successors.         |
-| Small capture or follow-up | none                      | #1899–#1902 | One paragraph of prose with a closing condition; check for an existing tracker first. |
+| Small capture or follow-up | none                      | #1900–#1902 | One paragraph of prose with a closing condition; check for an existing tracker first. |
 | Decision checkpoint        | none                      | #1899       | Verdict-first, per-trigger bullets, dated next checkpoint carried in the title.       |
 
 Shape selection failures worth knowing: the #1233 body took four shape

--- a/.agents/skills/github-prose/references/pr-shapes.md
+++ b/.agents/skills/github-prose/references/pr-shapes.md
@@ -16,8 +16,7 @@ merged local pull request; read it before drafting the same shape.
 4. Live-effect or follow-up closer, only when the change has one.
 
 Properties and invariants live in one durable document or nowhere; the
-body states what changed and what was checked. When review falsifies a
-claim, fix it by removing or shortening it, never by fencing it.
+body states what changed and what was checked.
 
 ## Shapes
 

--- a/.agents/skills/github-prose/references/pr-shapes.md
+++ b/.agents/skills/github-prose/references/pr-shapes.md
@@ -1,0 +1,35 @@
+# Pull request body shapes
+
+There is no `.github/` template for pull requests by design: agents pass
+the body explicitly, and GitHub offers no chooser for multiple pull
+request templates. The shape lives here instead. Every exemplar is a
+merged local pull request; read it before drafting the same shape.
+
+## The spine, common to all shapes
+
+1. Substance lead: what changed and why, in one or two sentences. No
+   preamble, no restating the request.
+2. Per-motion bullets when the change has more than two separable
+   motions, kept parallel in form.
+3. Validation: what was checked, what it showed, and what it cannot show.
+   Evidence-time detail, not command dumps.
+4. Live-effect or follow-up closer, only when the change has one.
+
+Properties and invariants live in one durable document or nowhere; the
+body states what changed and what was checked. When review falsifies a
+claim, fix it by removing or shortening it, never by fencing it.
+
+## Shapes
+
+| Shape                                   | Exemplar     | What distinguishes it                                                                                                                 |
+| --------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Mechanical batch change                 | #1877, #1884 | Lead names the batch and its rule; per-class bullets; a retained/held statement for what deliberately did not change.                 |
+| Gap-closing addition                    | #1878        | Gap stated first; per-item gap → fix → verification bullets; a scope-boundary section for what this does not change.                  |
+| Doctrine change                         | #1885        | Doctrine lead; per-motion bullets (reinstates, removes, stays, exception); final-state line.                                          |
+| Record correction                       | #1887, #1892 | Completion lead; evidence compressed to bullet leads; correct-in-place applies to misleading-but-not-false claims too.                |
+| ADR-adopting docs                       | #1895, #1896 | Why-now plus pointer; the merge is the decision; the body never re-argues the ADR's content.                                          |
+| Implementation with verification limits | #1904        | Phase-and-authority lead; per-source bullets; validation paragraph separating what pre-merge checks prove from what stays post-merge. |
+
+A version bump is reviewed on its own pull request; Renovate writes those
+bodies. For everything else, if no shape fits, use the spine alone —
+naming a new shape is worth a prose-log note.

--- a/.agents/skills/github-prose/references/review-contract.md
+++ b/.agents/skills/github-prose/references/review-contract.md
@@ -1,0 +1,46 @@
+# Review contract
+
+Governs how a review of drafted prose is conducted and reported. Domain
+rules live in `AGENTS.md` and the guides; the reviewer defers to them and
+flags a conflict with them rather than restating them.
+
+## Lenses
+
+Two passes catch disjoint defects; run both.
+
+- **Adversarial-factual**: try to falsify claims, weakest first. On a
+  restyle, enumerate every sentence that is new since the last verified
+  pass — fluent rewrites reopen factual risk on every touched sentence.
+- **Cold reader**: read as an uninitiated human operator. A readability
+  finding counts when that reader would misread a fact or a decision.
+  The verdict names the audience it certifies; five expert passes once
+  certified prose the owner found unreadable.
+
+## Findings
+
+- Severity-ranked, most severe first; each labelled Wrong, Unsupported,
+  Missing, or Disagree, and blocking or non-blocking.
+- Preferences are labelled as preferences and never block.
+- Never write "confirmed" for a source not read. Unverifiable claims are
+  reported as unknowns, not blockers. Re-verify numbers; never inherit
+  them.
+- No praise findings; omit sections with nothing to report; a trivial
+  artifact gets the compact form — verdict plus one line per item.
+
+## Verdict
+
+- Computed from the findings list: any actionable finding forces "accept
+  with changes". Style preferences alone cannot lower a verdict.
+- The reviewer declares a stop when the remaining work is testing, not
+  prose. A review loop without a declared stop diverges.
+
+## Convergence
+
+- Fix a wrong claim by removing or shortening it, never by fencing it
+  with qualifiers. A fix that lengthens the sentence it corrects needs
+  justification; qualifier accretion hands the next round a new target.
+- Probe classifications and counts ("is N the right number?", "are these
+  obvious?") — owner probing is the most effective lens on record, and a
+  reviewer should apply it before the owner has to.
+- Sentence-level patchwork collapses readability within two rounds; after
+  two, the fix is a holistic rewrite that preserves the agreed facts.

--- a/.agents/skills/github-prose/references/review-contract.md
+++ b/.agents/skills/github-prose/references/review-contract.md
@@ -14,7 +14,7 @@ Two passes catch disjoint defects; run both.
 - **Cold reader**: read as an uninitiated human operator. A readability
   finding counts when that reader would misread a fact or a decision.
   The verdict names the audience it certifies; five expert passes once
-  certified prose the owner found unreadable.
+  certified prose the owner found unreadable (#1233).
 
 ## Findings
 
@@ -42,5 +42,5 @@ Two passes catch disjoint defects; run both.
 - Probe classifications and counts ("is N the right number?", "are these
   obvious?") — owner probing is the most effective lens on record, and a
   reviewer should apply it before the owner has to.
-- Sentence-level patchwork collapses readability within two rounds; after
-  two, the fix is a holistic rewrite that preserves the agreed facts.
+- Sentence-level patchwork collapses readability; once it accumulates,
+  the fix is a holistic rewrite that preserves the agreed facts.

--- a/.github/ISSUE_TEMPLATE/audit-findings.md
+++ b/.github/ISSUE_TEMPLATE/audit-findings.md
@@ -1,0 +1,31 @@
+---
+name: Audit findings
+about: Record what an audit or inventory found and what inherits the findings.
+---
+
+<!--
+One line per paragraph; let the browser wrap. Delete any section that does not apply.
+Writing standards, template routing, and the public-safety checklist: docs/guides/pr-and-issue-writing.md.
+-->
+
+<!-- Lead paragraph, no heading: what was audited, and where detail that cannot be public lives. Findings that enumerate permissions, credentials, or internals stay in private notes; this issue records categories and conclusions. -->
+
+## Method
+
+<!-- What was inspected and how, including when each pass ran. Re-verify earlier findings against current state before posting; never inherit a stale claim. -->
+
+## Findings
+
+<!-- One row per finding. Severity and status always; add fix and suggested-order columns for defects, or a feeds column for findings that are design inputs. -->
+
+| Finding | Severity | Feeds | Status |
+| ------- | -------- | ----- | ------ |
+|         |          |       |        |
+
+## Conclusions
+
+<!-- What the findings mean taken together, and which work inherits them. -->
+
+## Completion criteria
+
+<!-- What must be true to close. Keep this body current; it is the record. -->

--- a/.github/ISSUE_TEMPLATE/tracking.md
+++ b/.github/ISSUE_TEMPLATE/tracking.md
@@ -1,6 +1,6 @@
 ---
 name: Tracking
-about: Track a programme or standing decision while the work lands elsewhere.
+about: Track a programme or a decision's delivery while the work lands elsewhere.
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/tracking.md
+++ b/.github/ISSUE_TEMPLATE/tracking.md
@@ -1,0 +1,31 @@
+---
+name: Tracking
+about: Track a programme or standing decision while the work lands elsewhere.
+---
+
+<!--
+One line per paragraph; let the browser wrap. Delete any section that does not apply.
+Writing standards, template routing, and the public-safety checklist: docs/guides/pr-and-issue-writing.md.
+-->
+
+<!-- Lead paragraph, no heading: the bare mandate — what this issue tracks and where the policy or evidence lives. Status rots here; keep it in Current state. -->
+
+## Principles
+
+<!-- Rules the tracked work must honour, one per bullet, as a summary plus a pointer to the canonical document rather than a copy of it. Delete when the work carries no doctrine. -->
+
+## Current state
+
+<!-- Outcome-first snapshot, kept current as work lands. Historical narrative belongs in the pull requests that did the work. -->
+
+## Work
+
+<!-- Checkboxes, one per completable action. Tick a box only when nothing future can falsify it; record partial progress as inline prose, not a half-ticked box. -->
+
+## Open decisions
+
+<!-- Questions the owner has not yet decided, one per bullet. Put them to the owner before drafting work that depends on them; delete the section when none remain. -->
+
+## Completion criteria
+
+<!-- What must be true to close. Keep this body current as work lands; it is the record. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,8 @@ line; read only those whose triggers match the task at hand.
 anything specific to a particular harness lives in the dotfiles layer, not
 here. Load a skill only when performing that task. Load `maintenance-window`
 before planning or executing any window that stops workloads, deletes or
-recreates PVCs, or holds imperative cluster state across a merge.
+recreates PVCs, or holds imperative cluster state across a merge. Load
+`github-prose` when drafting an issue, pull request body, or ADR.
 
 ## Before Editing
 

--- a/docs/guides/pr-and-issue-writing.md
+++ b/docs/guides/pr-and-issue-writing.md
@@ -59,6 +59,10 @@ body. Larger work starts from a template in `.github/ISSUE_TEMPLATE/`:
   a native GitHub sub-issue when it opens — links work only for issues,
   never pull requests — while the children table stays the record of status
   and dependencies.
+- **Tracking**: a programme or a decision's delivery, where the work lands
+  elsewhere and this issue holds the mandate, state, and open decisions.
+- **Audit findings**: what an audit or inventory found — method, findings,
+  conclusions — with identities kept to private notes.
 
 Templates are starting shapes: delete sections that do not apply, and rename a
 heading when that makes its contents more accurate.

--- a/docs/guides/pr-and-issue-writing.md
+++ b/docs/guides/pr-and-issue-writing.md
@@ -9,6 +9,10 @@ writing.
 The test for any sentence: would it exist if the work had been done right the
 first time, and does it help a later reader? If neither, cut it.
 
+The `github-prose` skill in `.agents/skills/` carries the drafting-to-posting
+process — artifact choice, shape catalogs, and the review contract. This
+guide stays canonical for the rules.
+
 ## Issues
 
 The body is the record. Keep it true as work lands — tick checkboxes, correct


### PR DESCRIPTION
Delivers #1915: the `github-prose` skill — artifact choice, pre-draft contract, drafting rules, review contract, posting mechanics, and body-as-record maintenance, with issue-shape, PR-shape, and review-contract references — plus the Tracking and Audit findings issue templates and two routing lines (root file and issue/PR guide). The skill defers to the guide throughout, so each rule keeps one canonical home, and every shape cites a merged local exemplar rather than restating its content.

Two research-backed decisions are carried in the diff: PR shapes are skill-carried rather than `.github/` templates, because GitHub offers no chooser for multiple PR templates, `gh pr create` cannot select them, and none of nine surveyed peer repositories use them; and the existing three issue templates stay where they are, with the two new ones joining them, since `.github/ISSUE_TEMPLATE/` is the surface GitHub's chooser reads.

Validation: 80-column wrap holds for prose (over-length lines follow the established one-liner, template-comment, and table conventions), all routing references resolve to existing files, every cited exemplar is a merged local PR or issue, and lefthook's format-markdown pass ran clean at commit.
