### PR TITLE
fix(konflate): pin the gatus probe to the site root

### DIFF
--- a/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
@@ -24,6 +24,12 @@ spec:
       existingSecret: konflate-webhook-token-secret
     httpRoute:
       enabled: true
+      # The gatus sidecar probes the route's first Exact/PathPrefix match,
+      # which is the /mcp deny rule below — pin the probe to the site root.
+      annotations:
+        gatus.home-operations.com/endpoint: |-
+          url: https://{{ .Release.Name }}.${SECRET_DOMAIN}/
+          conditions: ["[STATUS] == 200"]
       parentRefs:
         - name: envoy-external
           namespace: network


### PR DESCRIPTION
Gatus has shown Konflate down since #1907 merged. The gatus-sidecar derives its probe URL from the route's first path match, and #1907 deliberately prepended an external 404 for `/mcp` — so the monitor has been probing the one path built to refuse it, while Konflate itself is healthy (running pod, `Accepted=True` route; the 404s themselves prove edge routing, DNS, and TLS work). Pin the probe to the site root with the endpoint annotation, the same pattern kromgo uses for a route whose first rule is not the thing to probe.

Validation: the sidecar merges any subset of a Gatus endpoint from this annotation (upstream README), `/` is served by the retained catch-all rule, and `flate test all` renders clean (207 passed). The monitor recovers when the sidecar regenerates the endpoint after merge.
