### PR TITLE
feat(mise): default sessions to the read-only identities

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,9 +1,9 @@
 [env]
 FLATE_PATH = "{{config_root}}/kubernetes/flux/cluster"
-KUBECONFIG = "{{config_root}}/kubeconfig"
+KUBECONFIG = "{{config_root}}/kubeconfig-readonly"
 MINIJINJA_CONFIG_FILE = "{{config_root}}/.minijinja.toml"
 SOPS_AGE_KEY_FILE = "{{config_root}}/age.key"
-TALOSCONFIG = "{{config_root}}/talosconfig"
+TALOSCONFIG = "{{config_root}}/talosconfig-readonly"
 JUST_UNSTABLE = "1"
 
 _.file = ["{{config_root}}/.secrets.env"]

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -36,6 +36,12 @@ directory when possible:
 mise exec -- kubectl kustomize kubernetes/apps/<namespace>/<app>/app
 ```
 
+`kubectl apply --dry-run=server` runs admission with the caller's own
+permissions, and the ambient kubeconfig is read-only, so a server dry-run
+needs the administrative identity named explicitly:
+`mise exec -- kubectl --kubeconfig ./kubeconfig apply --dry-run=server ...`
+(the flag, not the environment — mise overrides an exported `KUBECONFIG`).
+
 ## What a local render does not prove
 
 The rendered `FluxInstance` pins its sync source to the remote `main` branch.

--- a/docs/operations/talos-access-and-break-glass.md
+++ b/docs/operations/talos-access-and-break-glass.md
@@ -14,6 +14,29 @@ short and factual; update it whenever API identities or access paths change.
 - The Talos API is addressed per node. The repo `talosconfig` lists the node
   hostnames as both endpoints and nodes; no VIP or proxy sits in the path.
 
+## Session identities (two per plane)
+
+Since #1921 the mise environment injects read-only credentials by default;
+the administrative files remain beside them and are selected explicitly by
+flag, never ambiently.
+
+- Kubernetes: `kubeconfig-readonly` authenticates the
+  `kube-system/agent-readonly` ServiceAccount — get/list/watch everywhere,
+  core-group Secrets excluded, no mutations. The identity's objects live in
+  `kubernetes/apps/kube-system/agent-access/`; revoke by deleting the token
+  Secret, re-mint by re-extracting it. Administrative path:
+  `mise exec -- kubectl --kubeconfig ./kubeconfig ...` (a flag, because the
+  mise environment overrides an exported variable).
+- Talos: `talosconfig-readonly` carries `os:reader` — reads work, sensitive
+  resources (machine config among them) and all mutations are denied.
+  Re-mint from the admin credential:
+  `talosctl config new talosconfig-readonly --roles os:reader -n m1 -e m1`
+  (a single node must be pinned). Administrative path:
+  `mise exec -- talosctl --talosconfig ./talosconfig ...`.
+- When an operator introduces a new API group, the PR that introduces it
+  adds the group to the `agent-readonly-extra` ClusterRole (or the operator
+  ships an aggregate-to-view label); re-run the capability listing after.
+
 ## Break-glass paths
 
 If the stable DNS name is unavailable (router or DNS failure):


### PR DESCRIPTION
Second PR for #1921, with both identities live-verified before this flip: the ambient KUBECONFIG and TALOSCONFIG now point at the read-only credentials — the agent-readonly ServiceAccount (capability listing confirms get, list, and watch across every served API group, core-group Secrets excluded, no mutations) and the os:reader Talos client (reads pass; machine config and all mutations denied). The administrative files stay beside them, reachable by explicit flag only — mise overrides an exported variable, so the flag is the documented path.

The access note gains the two-identity model with revocation and re-mint procedures, and the validation guide records the one behavioural consequence: a server dry-run runs admission with the caller's permissions, so it now names the admin kubeconfig explicitly.

Validation: `flate test all` renders clean (208 resources); the capability listings backing the verification claims are recorded in private notes.
