### PR TITLE
feat(mise): add the admin env profile for operator sittings

### DIFF
--- a/.mise/config.admin.toml
+++ b/.mise/config.admin.toml
@@ -1,0 +1,8 @@
+# Operator profile: `export MISE_ENV=admin` restores the administrative
+# credentials for an interactive sitting (and the just recipes run in it).
+# Agent sessions never set it; their explicit path stays the per-command
+# --kubeconfig/--talosconfig flag, and the ask rules gate mutating verbs
+# under either identity.
+[env]
+KUBECONFIG = "{{config_root}}/kubeconfig"
+TALOSCONFIG = "{{config_root}}/talosconfig"

--- a/docs/operations/talos-access-and-break-glass.md
+++ b/docs/operations/talos-access-and-break-glass.md
@@ -17,8 +17,10 @@ short and factual; update it whenever API identities or access paths change.
 ## Session identities (two per plane)
 
 Since #1921 the mise environment injects read-only credentials by default;
-the administrative files remain beside them and are selected explicitly by
-flag, never ambiently.
+the administrative files remain beside them. An interactive operator
+sitting selects them wholesale with `export MISE_ENV=admin` (profile in
+`.mise/config.admin.toml`, covering the just recipes too); agent sessions
+never set the profile and use the per-command flags below.
 
 - Kubernetes: `kubeconfig-readonly` authenticates the
   `kube-system/agent-readonly` ServiceAccount — get/list/watch everywhere,


### PR DESCRIPTION
Follow-up to #1924, which defaulted the ambient credentials to the read-only identities and left operator work paying a per-command flag. `.mise/config.admin.toml` restores the administrative KUBECONFIG and TALOSCONFIG for a whole interactive sitting via `export MISE_ENV=admin` — covering the just recipes — while sessions that never set the profile stay read-only. The ask rules gate mutating verbs under either identity, so the approval boundary is unmoved; the access note records the profile as the operator path beside the agents' per-command flags.

Validation: verified live in a worktree — default `mise env` resolves both variables to the read-only files, `MISE_ENV=admin mise env` resolves both to the administrative files.
