### PR TITLE
feat(flux): extend cosign verification to low/medium-risk chart sources

### DIFF
--- a/kubernetes/apps/ai/hermes/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/hermes/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 5.1.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/bjw-s-labs/helm-charts/\\.github/workflows/chart-release-steps\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/ai/litellm/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/litellm/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 5.1.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/bjw-s-labs/helm-charts/\\.github/workflows/chart-release-steps\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/ai/toolhive/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/toolhive/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 0.46.0
   url: oci://ghcr.io/stacklok/toolhive/toolhive-operator
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/stacklok/toolhive/\\.github/workflows/helm-publish\\.yml@refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+$"

--- a/kubernetes/apps/ai/toolhive/crds/ocirepository.yaml
+++ b/kubernetes/apps/ai/toolhive/crds/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 0.46.0
   url: oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/stacklok/toolhive/\\.github/workflows/helm-publish\\.yml@refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+$"

--- a/kubernetes/apps/default/agregarr/app/ocirepository.yaml
+++ b/kubernetes/apps/default/agregarr/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 5.1.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/bjw-s-labs/helm-charts/\\.github/workflows/chart-release-steps\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/default/atuin/app/ocirepository.yaml
+++ b/kubernetes/apps/default/atuin/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 5.1.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/bjw-s-labs/helm-charts/\\.github/workflows/chart-release-steps\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/default/autobrr/app/ocirepository.yaml
+++ b/kubernetes/apps/default/autobrr/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 5.1.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/bjw-s-labs/helm-charts/\\.github/workflows/chart-release-steps\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/default/bazarr/app/ocirepository.yaml
+++ b/kubernetes/apps/default/bazarr/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 5.1.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/bjw-s-labs/helm-charts/\\.github/workflows/chart-release-steps\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/default/brrpolice/app/ocirepository.yaml
+++ b/kubernetes/apps/default/brrpolice/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 5.1.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/bjw-s-labs/helm-charts/\\.github/workflows/chart-release-steps\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/default/chaski/app/ocirepository.yaml
+++ b/kubernetes/apps/default/chaski/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 0.5.1
   url: oci://ghcr.io/home-operations/charts/chaski
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/home-operations/chaski/\\.github/workflows/release\\.yaml@refs/tags/[0-9]+\\.[0-9]+\\.[0-9]+$"

--- a/kubernetes/apps/default/maintainerr/app/ocirepository.yaml
+++ b/kubernetes/apps/default/maintainerr/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 5.1.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/bjw-s-labs/helm-charts/\\.github/workflows/chart-release-steps\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/default/plex/app/ocirepository.yaml
+++ b/kubernetes/apps/default/plex/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 5.1.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/bjw-s-labs/helm-charts/\\.github/workflows/chart-release-steps\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/default/prowlarr/app/ocirepository.yaml
+++ b/kubernetes/apps/default/prowlarr/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 5.1.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/bjw-s-labs/helm-charts/\\.github/workflows/chart-release-steps\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/default/qbittorrent/app/ocirepository.yaml
+++ b/kubernetes/apps/default/qbittorrent/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 5.1.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/bjw-s-labs/helm-charts/\\.github/workflows/chart-release-steps\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/default/qui/app/ocirepository.yaml
+++ b/kubernetes/apps/default/qui/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 5.1.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/bjw-s-labs/helm-charts/\\.github/workflows/chart-release-steps\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/default/radarr-se/app/ocirepository.yaml
+++ b/kubernetes/apps/default/radarr-se/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 5.1.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/bjw-s-labs/helm-charts/\\.github/workflows/chart-release-steps\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/default/radarr/app/ocirepository.yaml
+++ b/kubernetes/apps/default/radarr/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 5.1.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/bjw-s-labs/helm-charts/\\.github/workflows/chart-release-steps\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/default/recyclarr/app/ocirepository.yaml
+++ b/kubernetes/apps/default/recyclarr/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 5.1.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/bjw-s-labs/helm-charts/\\.github/workflows/chart-release-steps\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/default/resolute/app/ocirepository.yaml
+++ b/kubernetes/apps/default/resolute/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 5.1.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/bjw-s-labs/helm-charts/\\.github/workflows/chart-release-steps\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/default/sabnzbd/app/ocirepository.yaml
+++ b/kubernetes/apps/default/sabnzbd/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 5.1.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/bjw-s-labs/helm-charts/\\.github/workflows/chart-release-steps\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/default/seerr/app/ocirepository.yaml
+++ b/kubernetes/apps/default/seerr/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 5.1.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/bjw-s-labs/helm-charts/\\.github/workflows/chart-release-steps\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/default/sonarr/app/ocirepository.yaml
+++ b/kubernetes/apps/default/sonarr/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 5.1.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/bjw-s-labs/helm-charts/\\.github/workflows/chart-release-steps\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/flux-system/konflate/app/ocirepository.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 0.6.2
   url: oci://ghcr.io/home-operations/charts/konflate
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/home-operations/konflate/\\.github/workflows/release\\.yaml@refs/tags/[0-9]+\\.[0-9]+\\.[0-9]+$"

--- a/kubernetes/apps/kube-system/descheduler/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/descheduler/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 0.36.0
   url: oci://ghcr.io/home-operations/charts-mirror/descheduler
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/home-operations/charts-mirror/\\.github/workflows/app-builder\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/kube-system/drm-exporter/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/drm-exporter/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 0.3.3
   url: oci://ghcr.io/home-operations/charts/drm-exporter
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/home-operations/drm-exporter/\\.github/workflows/release\\.yaml@refs/tags/[0-9]+\\.[0-9]+\\.[0-9]+$"

--- a/kubernetes/apps/kube-system/metrics-server/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 3.14.0
   url: oci://ghcr.io/home-operations/charts-mirror/metrics-server
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/home-operations/charts-mirror/\\.github/workflows/app-builder\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/kube-system/reloader/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/reloader/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 2.2.16
   url: oci://ghcr.io/stakater/charts/reloader
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/stakater/Reloader/\\.github/workflows/push-helm-chart\\.yaml@refs/heads/master$"

--- a/kubernetes/apps/kube-system/spegel/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/spegel/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 0.7.4
   url: oci://ghcr.io/spegel-org/helm-charts/spegel
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/spegel-org/spegel/\\.github/workflows/release\\.yaml@refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+$"

--- a/kubernetes/apps/observability/gatus-sidecar/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/gatus-sidecar/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 0.5.2
   url: oci://ghcr.io/home-operations/charts/gatus-sidecar
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/home-operations/gatus-sidecar/\\.github/workflows/release\\.yaml@refs/tags/[0-9]+\\.[0-9]+\\.[0-9]+$"

--- a/kubernetes/apps/observability/kromgo/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/kromgo/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 0.16.1
   url: oci://ghcr.io/home-operations/charts/kromgo
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/home-operations/kromgo/\\.github/workflows/release\\.yaml@refs/tags/[0-9]+\\.[0-9]+\\.[0-9]+$"

--- a/kubernetes/apps/observability/unpoller/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/unpoller/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 5.1.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/bjw-s-labs/helm-charts/\\.github/workflows/chart-release-steps\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/observability/victoria-logs/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 0.13.9
   url: oci://ghcr.io/victoriametrics/helm-charts/victoria-logs-single
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/VictoriaMetrics/helm-charts/\\.github/workflows/release\\.yaml@refs/heads/master$"

--- a/kubernetes/apps/observability/victoria-logs/collector/ocirepository.yaml
+++ b/kubernetes/apps/observability/victoria-logs/collector/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 0.3.7
   url: oci://ghcr.io/victoriametrics/helm-charts/victoria-logs-collector
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/VictoriaMetrics/helm-charts/\\.github/workflows/release\\.yaml@refs/heads/master$"


### PR DESCRIPTION
The low/medium-risk extension from #1894: 33 OCIRepository sources across 14 chart artifacts gain identity-bound cosign verify blocks. This lands ahead of the soak gate, per the sequencing decision recorded in #1894.

Held back for later phases: the high-risk batch (secrets, CNI, storage, DNS, backup path), the bootstrap-critical Flux sources, cloudflare-tunnel as the sole public ingress, and tuppr as the Talos upgrade driver. The 15 unsigned or unverifiable sources stay excluded, per the issue's inventory.

Every identity was re-validated on 2026-08-31 against the currently pinned artifact — nothing inherited from the 2026-08-07 audit. `cosign verify` passes for all 14 artifacts using the exact issuer and subject regexes in these manifests. Formats: legacy `.sig` for app-template, cosign v3 DSSE bundles for the rest. Tag-ref subjects pin the version pattern (`v`-prefixed for stacklok and spegel, bare for home-operations); branch-ref subjects anchor the literal ref. Trust classes and observed subjects go into #1894's adoption records at merge.

If verification fails on any of these sources, that source freezes with `SourceVerified=False` and the running release is untouched. #1894's abort condition stands.
