### PR TITLE
feat(default): add explicit memory requests to the arr stack

### DIFF
--- a/kubernetes/apps/default/agregarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/agregarr/app/helmrelease.yaml
@@ -47,6 +47,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 512Mi
               limits:
                 memory: 1Gi
             securityContext:

--- a/kubernetes/apps/default/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/bazarr/app/helmrelease.yaml
@@ -51,6 +51,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 512Mi
               limits:
                 memory: 1Gi
     defaultPodOptions:

--- a/kubernetes/apps/default/maintainerr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/maintainerr/app/helmrelease.yaml
@@ -58,6 +58,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 768Mi
               limits:
                 memory: 1Gi
     defaultPodOptions:

--- a/kubernetes/apps/default/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/prowlarr/app/helmrelease.yaml
@@ -61,6 +61,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 512Mi
               limits:
                 memory: 1Gi
     defaultPodOptions:

--- a/kubernetes/apps/default/qui/app/helmrelease.yaml
+++ b/kubernetes/apps/default/qui/app/helmrelease.yaml
@@ -56,7 +56,8 @@ spec:
                   periodSeconds: 10
             resources:
               requests:
-                cpu: 10m
+                cpu: 50m
+                memory: 512Mi
               limits:
                 memory: 1Gi
             securityContext:

--- a/kubernetes/apps/default/radarr-se/app/helmrelease.yaml
+++ b/kubernetes/apps/default/radarr-se/app/helmrelease.yaml
@@ -61,6 +61,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 1Gi
               limits:
                 memory: 4Gi
     defaultPodOptions:

--- a/kubernetes/apps/default/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/radarr/app/helmrelease.yaml
@@ -61,6 +61,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 1Gi
               limits:
                 memory: 4Gi
     defaultPodOptions:

--- a/kubernetes/apps/default/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/seerr/app/helmrelease.yaml
@@ -55,6 +55,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 1Gi
               limits:
                 memory: 2Gi
     defaultPodOptions:

--- a/kubernetes/apps/default/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/sonarr/app/helmrelease.yaml
@@ -66,6 +66,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 1Gi
               limits:
                 memory: 4Gi
     defaultPodOptions:

--- a/kubernetes/apps/default/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/default/tautulli/app/helmrelease.yaml
@@ -54,6 +54,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 256Mi
               limits:
                 memory: 1Gi
     defaultPodOptions:


### PR DESCRIPTION
Phase 1 of #1765. Ten arr-stack apps get explicit memory requests instead of inheriting their limits, and qui's CPU request rises from 10m to 50m. Limits are unchanged.

Values are the issue's proposal re-checked against a fresh 14-day window ending 2026-08-30; no workload recorded an OOM kill in it. Two values differ from the original table: sonarr rises to 1Gi because its fresh p95 reached the proposed 768Mi, and radarr-se is set to 1Gi to match radarr rather than the tighter 512Mi first proposed.

| app | request before (inherited) | fresh 14d p95 / max | request now |
|---|---|---|---|
| radarr | 4Gi | 744Mi / 847Mi | 1Gi |
| radarr-se | 4Gi | 286Mi / 331Mi | 1Gi |
| sonarr | 4Gi | 768Mi / 881Mi | 1Gi |
| seerr | 2Gi | 380Mi / 430Mi | 1Gi |
| agregarr | 1Gi | 312Mi / 323Mi | 512Mi |
| bazarr | 1Gi | 296Mi / 301Mi | 512Mi |
| maintainerr | 1Gi | 414Mi / 459Mi | 768Mi |
| prowlarr | 1Gi | 308Mi / 344Mi | 512Mi |
| qui | 1Gi | 229Mi / 258Mi | 512Mi |
| tautulli | 1Gi | 126Mi / 127Mi | 256Mi |

The node picture, per the issue's Phase 1 requirement:

- Today: 33.4–39.8Gi requested memory per node (56–67% of allocatable); 4.15–5.83 CPU cores (52–73%).
- After the full #1765 proposal, projected onto current placement: 18.3–22.0Gi per node (31–37%); CPU nearly unchanged.
- Losing any one node: the reschedulable pods (DaemonSets, static pods, and node-bound Rook OSDs excluded) fit on the survivors with +15.0Gi memory to spare today, +65.1Gi after the full proposal. CPU margin moves from +2.48 to +2.66 cores.
- The aggregate fit is necessary but not sufficient: volumes, placement constraints, and node-bound workloads still limit what can actually reschedule.
