### PR TITLE
fix(kube-system): roll coredns back to 1.46.2 and hold

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -50,6 +50,13 @@
       matchUpdateTypes: ["minor", "patch"],
       automerge: false,
     },
+    // Hold rules
+    {
+      description: "Hold coredns chart at 1.46.2: CoreDNS >=1.14.3 breaks autopath during cache prefetch, https://www.github.com/coredns/coredns/issues/8390",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["/coredns/"],
+      allowedVersions: "<=1.46.2",
+    },
     // Grouping rules
     {
       description: "Actions Runner Controller Group",

--- a/kubernetes/apps/kube-system/coredns/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.47.0
+    tag: 1.46.2
   url: oci://ghcr.io/coredns/charts/coredns


### PR DESCRIPTION
We run the exact combination CoreDNS 1.14.x broke: `autopath @kubernetes`, `pods verified`, and a cache with `prefetch 20`. From 1.14.3, cache prefetch refreshes entries with a synthetic empty client address. Autopath then cannot resolve the source pod, the search-expanded name gets NXDOMAIN from the kubernetes plugin, and the cache serves that negative answer ahead of the positive one. Our AAAA blackhole masks none of this for A records.

This rolls the chart back to 1.46.2 (CoreDNS 1.13.1), the version we ran until #1657, and adds a Renovate hold pointing at the upstream issue (https://www.github.com/coredns/coredns/issues/8390). No values change: every stanza we set exists in 1.13.1. The `template ANY AAAA` block stays — ours is a deliberate IPv4-only design choice with a documented dependent (thelounge, #1690), not a bug mask.

Verified: the live Corefile (read from the ConfigMap) matches the vulnerable shape on the running 1.14.6 image; the rollback renders clean. Adapted from https://www.github.com/onedr0p/home-ops/pull/11619; its other two parts do not apply here — our nodes receive no DHCP search domain (all three report empty `searchDomains` live), and our AAAA template serves a different purpose than their removed one.
