### PR TITLE
chore(default): rename disk-backed tmpfs volumes to tmp

### DIFF
--- a/kubernetes/apps/default/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/default/plex/app/helmrelease.yaml
@@ -119,7 +119,7 @@ spec:
           - path: /data/media
             subPath: media
             readOnly: true
-      tmpfs:
+      tmp:
         type: emptyDir
         advancedMounts:
           plex:

--- a/kubernetes/apps/default/resolute/app/helmrelease.yaml
+++ b/kubernetes/apps/default/resolute/app/helmrelease.yaml
@@ -145,7 +145,7 @@ spec:
               - path: /config/policy.yaml
                 subPath: policy.yaml
                 readOnly: true
-      tmpfs:
+      tmp:
         type: emptyDir
         globalMounts:
           - path: /tmp

--- a/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
@@ -94,7 +94,7 @@ spec:
         globalMounts:
           - path: /data/usenet
             subPath: usenet
-      tmpfs:
+      tmp:
         type: emptyDir
         advancedMounts:
           sabnzbd:

--- a/kubernetes/apps/default/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/seerr/app/helmrelease.yaml
@@ -88,7 +88,7 @@ spec:
         existingClaim: "{{ .Release.Name }}-cache"
         globalMounts:
           - path: /app/config/cache
-      tmpfs:
+      tmp:
         type: emptyDir
         advancedMounts:
           seerr:

--- a/kubernetes/apps/default/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/default/tautulli/app/helmrelease.yaml
@@ -82,7 +82,7 @@ spec:
         existingClaim: "{{ .Release.Name }}-cache"
         globalMounts:
           - path: /config/cache
-      tmpfs:
+      tmp:
         type: emptyDir
         advancedMounts:
           tautulli:

--- a/kubernetes/apps/default/thelounge/app/helmrelease.yaml
+++ b/kubernetes/apps/default/thelounge/app/helmrelease.yaml
@@ -79,7 +79,7 @@ spec:
     persistence:
       config:
         existingClaim: "{{ .Release.Name }}"
-      tmpfs:
+      tmp:
         type: emptyDir
         sizeLimit: 1Gi
         advancedMounts:


### PR DESCRIPTION
Six apps name a disk-backed emptyDir `tmpfs`: plex, sabnzbd, tautulli, seerr, thelounge, and resolute. None sets `medium: Memory`, so none of them is tmpfs — the name says RAM, the volume is disk. The mislabel caused real confusion during the #1765 audit: Plex transcode files land on disk while their page cache still counts toward pod memory.

This renames the volume key to `tmp` in all six, matching sonarr, the one app that already had it right. Mounts and subPaths are unchanged; each app restarts once as its pod template changes. This also satisfies the #1765 item to rename Plex's volume in its cohort.
