### PR TITLE
feat(network): re-run eTP Local echo experiment on cilium 1.20.1

### DIFF
--- a/kubernetes/apps/network/echo/app/kustomization.yaml
+++ b/kubernetes/apps/network/echo/app/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./service-local.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/network/echo/app/service-local.yaml
+++ b/kubernetes/apps/network/echo/app/service-local.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-local
+  annotations:
+    lbipam.cilium.io/ips: 192.168.96.250
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  selector:
+    app.kubernetes.io/instance: echo
+    app.kubernetes.io/name: echo
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http


### PR DESCRIPTION
Re-runs the #1536 disposable experiment on Cilium 1.20.1, for #1902. The 1.20.0 release consolidated the BGP control-plane internals, so per-node advertisement and withdrawal need re-verification before any production service adopts `externalTrafficPolicy: Local`.

Same shape as #1551: a second LoadBalancer Service for echo with `Local` policy on a spare pool address. Echo runs two replicas on two of three nodes, so the expected picture is six advertised routes on the endpoint-bearing nodes, five on the third, withdrawal when a pod dies, and re-advertisement within seconds. Results land in #1902; a follow-up PR removes the Service, like #1552.
