### PR TITLE
chore: align probe outliers, dedupe flux concurrency flag, drop reloader HA

### DIFF
--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -41,8 +41,8 @@ spec:
                   tcpSocket:
                     port: &dashboardPort 9119
                   periodSeconds: 10
-                  timeoutSeconds: 1
-                  failureThreshold: 3
+                  timeoutSeconds: 5
+                  failureThreshold: 5
             resources:
               requests:
                 cpu: 100m

--- a/kubernetes/apps/ai/litellm/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/litellm/app/helmrelease.yaml
@@ -31,17 +31,26 @@ spec:
               - secretRef:
                   name: "{{ .Release.Name }}-secret"
             probes:
-              liveness: &probes
+              liveness:
                 enabled: true
                 custom: true
                 spec:
                   httpGet:
                     path: /
                     port: &port 4000
-                  initialDelaySeconds: 5
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *port
                   periodSeconds: 10
-                  failureThreshold: 3
-              readiness: *probes
+                  timeoutSeconds: 5
+                  failureThreshold: 5
               startup:
                 enabled: true
                 custom: true

--- a/kubernetes/apps/default/thelounge/app/helmrelease.yaml
+++ b/kubernetes/apps/default/thelounge/app/helmrelease.yaml
@@ -45,8 +45,16 @@ spec:
             probes:
               liveness:
                 enabled: true
+                spec:
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
               readiness:
                 enabled: true
+                spec:
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
               startup:
                 enabled: true
                 spec:

--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
                 value: --requeue-dependency=5s
             target:
               kind: Deployment
-              name: (kustomize-controller|helm-controller|source-controller)
+              name: (helm-controller|source-controller)
           - # Increase the memory limits
             patch: |-
               apiVersion: apps/v1
@@ -61,6 +61,9 @@ spec:
               - op: add
                 path: /spec/template/spec/containers/0/args/-
                 value: --concurrent=20
+              - op: add
+                path: /spec/template/spec/containers/0/args/-
+                value: --requeue-dependency=5s
               - op: replace
                 path: /spec/template/spec/volumes/0
                 value:

--- a/kubernetes/apps/kube-system/reloader/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/reloader/app/helmrelease.yaml
@@ -12,9 +12,6 @@ spec:
   values:
     fullnameOverride: reloader
     reloader:
-      enableHA: true
-      deployment:
-        replicas: 1
       readOnlyRootFileSystem: true
       podMonitor:
         enabled: true

--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -33,18 +33,26 @@ spec:
               - tunnel
               - run
             probes:
-              liveness: &probes
+              liveness:
                 enabled: true
                 custom: true
                 spec:
                   httpGet:
                     path: /ready
                     port: &port 8080
-                  initialDelaySeconds: 0
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ready
+                    port: *port
                   periodSeconds: 10
-                  timeoutSeconds: 1
-                  failureThreshold: 3
-              readiness: *probes
+                  timeoutSeconds: 5
+                  failureThreshold: 5
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true

--- a/kubernetes/apps/observability/unpoller/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/unpoller/app/helmrelease.yaml
@@ -27,18 +27,26 @@ spec:
               - secretRef:
                   name: "{{ .Release.Name }}-secret"
             probes:
-              liveness: &probes
+              liveness:
                 enabled: true
                 custom: true
                 spec:
                   httpGet:
                     path: /health
                     port: &port 80
-                  initialDelaySeconds: 0
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
                   periodSeconds: 10
-                  timeoutSeconds: 1
-                  failureThreshold: 3
-              readiness: *probes
+                  timeoutSeconds: 5
+                  failureThreshold: 5
               startup:
                 enabled: true
                 spec:


### PR DESCRIPTION
Three hygiene fixes from a config review against the repo's own norms.

Probes: seventeen apps share one shape — 5s timeouts, failure threshold 5, liveness every 30s, readiness every 10s. Five had drifted to 1-second timeouts and threshold 3: cloudflare-tunnel, unpoller, thelounge (bare chart defaults), hermes, and litellm. All five now match the norm. Hermes keeps its readiness-only shape; adding probe types it never had was out of scope.

flux-instance: the worker patch targeted all three controllers, so kustomize-controller carried both `--concurrent=10` and `--concurrent=20` — confirmed in the live args, where the last flag happens to win. The patch now targets helm-controller and source-controller only, and kustomize-controller gets `--concurrent=20` plus `--requeue-dependency=5s` in its own patch: exactly one of each flag per controller.

reloader: `enableHA: true` with `replicas: 1` is contradictory — the chart documents HA as only for multiple replicas and defaults to one replica anyway. Both keys dropped.

Probe diffs and controller args were checked against the live deployments before drafting; renders clean. Probe and reloader items adapted from https://www.github.com/onedr0p/home-ops/pull/11614; its tool-pin fixes do not apply here (ours are fresh and Renovate-tracked).
