### PR TITLE
chore(talos): raise tcp autotuning caps, drop idle hugepages reservation

### DIFF
--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -95,12 +95,11 @@ machine:
     net.ipv4.tcp_congestion_control: bbr
     net.ipv4.tcp_fastopen: "3"
     net.ipv4.tcp_notsent_lowat: "131072"
-    net.ipv4.tcp_rmem: 4096 87380 33554432
+    net.ipv4.tcp_rmem: 4096 131072 67108864
     net.ipv4.tcp_slow_start_after_idle: "0"
     net.ipv4.tcp_window_scaling: "1"
-    net.ipv4.tcp_wmem: 4096 65536 33554432
+    net.ipv4.tcp_wmem: 4096 65536 67108864
     user.max_user_namespaces: "11255"
-    vm.nr_hugepages: "1024"
   token: op://kubernetes/talos/MACHINE_TOKEN
 cluster:
   ca:


### PR DESCRIPTION
Two sysctl corrections, decided against live counters.

`net.ipv4.tcp_rmem` / `tcp_wmem` max rises from 32MiB to 64MiB, matching the `net.core` ceilings already set — TCP autotuning could never reach them. `tcp_rmem[1]` returns to 131072, the Talos default our explicit value had silently lowered. Pod network namespaces inherit all of these.

`vm.nr_hugepages: 1024` is removed. No workload requests hugepages and node-exporter shows all 1024 pages free on every node — 2GiB per node reserved and idle.

Left alone deliberately: backlog knobs (softnet drops, ListenOverflows and ListenDrops are zero on all nodes), `ip_local_port_range` (kernel default, no pressure evidence), and nfs `nconnect`, already 16. Adapted from https://www.github.com/onedr0p/home-ops/pull/11608.

Rollout: machine config does not apply via Flux. After merge, `just talos apply-node <node>` per node — the sysctls apply without a reboot. Verify with `talosctl get kernelparamstatuses`; if the live hugepages count does not drop immediately, it clears fully at each node's next reboot.
