### PR TITLE
feat(default): add explicit memory requests to the big media apps

### DIFF
--- a/kubernetes/apps/default/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/default/plex/app/helmrelease.yaml
@@ -54,6 +54,7 @@ spec:
                 - name: gpu
               requests:
                 cpu: 100m
+                memory: 4Gi
               limits:
                 memory: 16Gi
     defaultPodOptions:

--- a/kubernetes/apps/default/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/default/qbittorrent/app/helmrelease.yaml
@@ -52,6 +52,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 2Gi
               limits:
                 memory: 18Gi
     defaultPodOptions:

--- a/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
@@ -62,6 +62,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 1Gi
               limits:
                 memory: 12Gi
     defaultPodOptions:


### PR DESCRIPTION
Cohort 2 of #1765: qbittorrent, plex, and sabnzbd get explicit memory requests, replacing limit-inherited reservations of 18Gi, 16Gi, and 12Gi. Limits are unchanged. This is the largest single reclaim in the proposal: 41Gi of phantom requests become 7Gi of measured ones.

| app | request before (inherited) | fresh 14d p95 / max | request now |
|---|---|---|---|
| qbittorrent | 18Gi | 787Mi / 1807Mi | 2Gi |
| plex | 16Gi | 556Mi / 1411Mi | 4Gi |
| sabnzbd | 12Gi | 78Mi / 298Mi | 1Gi |

Plex lands at 4Gi rather than the issue's 2Gi: transcode page cache counts toward pod memory, and the one peer precedent for an explicit request under a 16Gi limit sits at 4Gi. The deviation is recorded in #1765 at completion. The window includes a full node-outage reschedule cycle for all three apps and no OOM kills. The `tmpfs` volume rename the issue couples to this cohort landed separately (#1931).
