### PR TITLE
feat: correct ai and observability resource requests

### DIFF
--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -46,6 +46,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 1Gi
               limits:
                 memory: 2Gi
     defaultPodOptions:

--- a/kubernetes/apps/ai/litellm/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/litellm/app/helmrelease.yaml
@@ -64,7 +64,7 @@ spec:
             resources:
               requests:
                 cpu: 50m
-                memory: 256Mi
+                memory: 1.5Gi
               limits:
                 memory: 2Gi
             securityContext:

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -68,7 +68,7 @@ spec:
         retentionSize: 40GiB
         resources:
           requests:
-            cpu: 100m
+            cpu: 250m
           limits:
             memory: 3Gi
         storageSpec:

--- a/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
@@ -19,6 +19,10 @@ spec:
         enabled: true
     server:
       fullnameOverride: victoria-logs
+      resources:
+        requests:
+          cpu: 25m
+          memory: 1Gi
       persistentVolume:
         enabled: true
         storageClassName: ceph-block


### PR DESCRIPTION
Cohort 3 of #1765: the mis-sized and missing requests outside the media stack. Limits unchanged.

| app | request before | fresh 14d p95 / max | request now |
|---|---|---|---|
| hermes (memory) | 2Gi (inherited) | 355Mi / 356Mi | 1Gi |
| litellm (memory) | 256Mi | 707Mi / 708Mi (flat) | 1.5Gi |
| victoria-logs (memory) | none | 483Mi / 767Mi | 1Gi |
| victoria-logs (CPU) | none | 12m / 32m | 25m |
| prometheus (CPU) | 100m | 116m / 210m | 250m |

Two evidence notes. litellm's flat profile moved from 1.1Gi to 707Mi across a version bump; 1.5Gi stays deliberately conservative because the profile is version-dependent. victoria-logs rises from the proposed 768Mi to 1Gi because the fresh maximum reached 767Mi. Prometheus's figures span the engine migration (#1873/#1874); steady-state upstream CPU (108m p95 / 153m max) fits 250m.
