### PR TITLE
feat(kube-system): right-size descheduler requests

### DIFF
--- a/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
@@ -11,6 +11,10 @@ spec:
   interval: 1h
   values:
     kind: Deployment
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
     deschedulerPolicyAPIVersion: descheduler/v1alpha2
     deschedulerPolicy:
       profiles:


### PR DESCRIPTION
Cohort 4 of #1765, the last: the descheduler chart defaults to requests equal to limits at 500m CPU / 256Mi, while observed use over 14 days is about 1m CPU and 90Mi. This sets requests to 100m / 128Mi; Helm's deep merge leaves the chart's default limits in place, so only the reservation changes.

The pod drops from Guaranteed to Burstable QoS — a deliberate trade for honest requests on a stateless controller, recorded in #1765 at completion. Peer practice splits the same way: ten peers keep the Guaranteed default untouched, and the one that overrides uses exactly these request values.
