### PR TITLE
docs: correct automerge, dependsOn, and verify-block staleness

### DIFF
--- a/.agents/skills/add-app/SKILL.md
+++ b/.agents/skills/add-app/SKILL.md
@@ -45,7 +45,7 @@ Confirm with the user anything not already given:
 4. **Persistence**: choose backup posture from the app's value and recovery
    requirements, not from the presence of a PVC. Protected application state
    (the norm in the `default` namespace) uses the Kopiur component, which
-   supplies the PVC and its backups and requires the Rook-Ceph dependency.
+   supplies the PVC and its backups.
    Some persistent workloads — observability data especially — intentionally
    use plain PVCs with no backup coverage; do not add coverage just because
    the app is stateful.
@@ -58,7 +58,8 @@ Confirm with the user anything not already given:
    instead (see resolute's `secret.sops.yaml`) — that is an exception, not
    the default. Ordinary credentials always go through
    1Password/ExternalSecret; never encrypt them directly into Git.
-7. **Dependencies**: other Flux Kustomizations this app needs (`dependsOn`).
+7. **Dependencies**: almost never — `dependsOn` follows the doctrine in
+   `docs/guides/cluster-model.md`; the default is none.
 
 ## Step 2: Create the files
 
@@ -77,7 +78,7 @@ kubernetes/apps/<namespace>/<app>/
 
 Copy atuin's `ks.yaml`. Keep the key order and drop what does not apply:
 
-- `components` + `dependsOn` (rook-ceph-cluster): only with a Kopiur PVC.
+- `components` (kopiur): only with a Kopiur PVC.
 - `postBuild.substitute.APP` is required by the Kopiur component; add
   `PVC_CAPACITY` when the component default (5Gi) is wrong.
 - `postBuild.substituteFrom: cluster-secrets`: needed for `${SECRET_DOMAIN}`
@@ -97,7 +98,10 @@ recyclarr's `configMapGenerator` block (name `<app>-configmap`, one entry per
 ### app/ocirepository.yaml
 
 Copy atuin's. The chart is `oci://ghcr.io/bjw-s-labs/helm/app-template`; use
-the same chart tag as nearby apps (Renovate bumps it).
+the same chart tag as nearby apps (Renovate bumps it). Keep atuin's `verify`
+block verbatim — it pins the app-template signing identity. For any other
+chart, derive the identity per ADR-0003 (or omit `verify` and record the
+source as unverified); never copy another chart's identity.
 
 ### app/helmrelease.yaml
 
@@ -120,7 +124,9 @@ Copy atuin's and adapt. Invariants to keep:
   readiness probe when the app has a health endpoint.
 - `resources`: start at `requests.cpu: 10m` with a memory limit sized to the
   app; heavier apps in this repo run `100m`, so match a comparable app rather
-  than the minimum.
+  than the minimum. Apps with a meaningful memory footprint also set an
+  explicit `requests.memory` below the limit (see the arr stack); match a
+  comparable app.
 - Route hostnames use `"{{ .Release.Name }}.${SECRET_DOMAIN}"`; never hardcode
   the domain. Public routes get a Gatus endpoint annotation (see plex).
 - Kopiur-backed persistence mounts `existingClaim: "{{ .Release.Name }}"`.

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ the applications under `kubernetes/apps`.
 ## Automation / CI
 
 Renovate manages dependency updates for charts, containers, GitHub Actions, and
-other versioned references. Most updates use pull requests; selected low-risk
-classes may branch-automerge.
+other versioned references. All updates use pull requests; selected low-risk
+classes auto-merge once the required checks pass.
 
 Pull request checks and reviewers are:
 

--- a/docs/guides/app-pattern.md
+++ b/docs/guides/app-pattern.md
@@ -50,7 +50,8 @@ one.
 The namespace-level `kustomization.yaml` includes each app `ks.yaml`. The app
 `ks.yaml` points Flux at the `app/` directory, usually sets `targetNamespace`,
 adds `postBuild.substituteFrom` for `cluster-secrets`, and declares
-dependencies such as Rook-Ceph when needed.
+`dependsOn` only where the doctrine in
+[`cluster-model.md`](cluster-model.md) requires it — rare for ordinary apps.
 
 Prefer existing bjw-s app-template values for app workloads:
 

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -185,7 +185,8 @@ workflow checks above. In the pull request or merge note, record why the bypass
 was needed and which local commands passed. After merging, watch the
 GitHub-hosted `Render` alarm and Flux reconciliation for the merged revision.
 
-Docs-only direct-to-main commits (allowed for low-risk changes with explicit
-approval, per `AGENTS.md`) also bypass the required checks. They need only
+Docs-only direct-to-main commits require the repo-admin ruleset bypass — they
+skip both the pull-request requirement and the required checks — and are for
+low-risk changes with explicit approval. They need only
 `oxfmt --check` locally and no cluster validation, matching the docs-only
 change heuristic; note the bypass in the commit or the session record.

--- a/docs/operations/ai-workbench.md
+++ b/docs/operations/ai-workbench.md
@@ -166,8 +166,8 @@ Promotion criteria:
 ## Hermes Skills And Memory
 
 Hermes UI skills are runtime state unless this repo adopts them. Repo-local
-skills live under `.agents/skills/<name>/SKILL.md` — `add-app` and
-`maintenance-window`. Narrow reusable conventions live in
+skills live under `.agents/skills/<name>/SKILL.md` — `add-app`,
+`github-prose`, and `maintenance-window`. Narrow reusable conventions live in
 `docs/guides/`.
 
 Before relying on generated skills, confirm this guardrail posture in the


### PR DESCRIPTION
A staleness sweep of the durable docs against current reality. Corrections:

- README: all Renovate updates now go through pull requests; the branch-automerge sentence described the pre-#1928 world.
- validation.md: docs-only direct-to-main commits now bypass a pull-request requirement, not just checks, and need the repo-admin ruleset bypass. The sentence also cited an allowance `AGENTS.md` does not contain, so it now states the mechanism directly.
- add-app skill: the Kopiur component no longer requires a rook-ceph-cluster `dependsOn` (removed in the #1872 doctrine work); the dependencies intake question now points at the doctrine instead of inviting edges; the OCIRepository step warns against copying another chart's cosign identity now that sources carry verify blocks; and the resources guidance covers explicit memory requests.
- app-pattern.md: `dependsOn` guidance points at the cluster-model doctrine instead of naming the removed Rook-Ceph example.
- ai-workbench.md: the repo-local skill list gains github-prose.

Checked and found clean in the same sweep: cluster-model.md's 18-edge doctrine table (verified edge-by-edge against the manifests), node-upgrades.md's descheduler description, storage-and-backups.md's protected inventory, yaml-ordering, peers, and pr-and-issue-writing.
