### PR TITLE
feat(default): set allowed hosts and trusted networks on radarr and prowlarr

### DIFF
--- a/kubernetes/apps/default/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/prowlarr/app/helmrelease.yaml
@@ -26,7 +26,9 @@ spec:
               PROWLARR__AUTH__REQUIRED: DisabledForLocalAddresses
               PROWLARR__LOG__DBENABLED: "False"
               PROWLARR__LOG__LEVEL: info
+              PROWLARR__SERVER__ALLOWEDHOSTS: "{{ .Release.Name }}.${SECRET_DOMAIN},prowlarr.default.svc.cluster.local"
               PROWLARR__SERVER__PORT: &port 80
+              PROWLARR__SERVER__TRUSTEDNETWORKS: 10.69.0.0/16
               PROWLARR__UPDATE__BRANCH: develop
               TZ: Pacific/Auckland
             envFrom:
@@ -46,6 +48,9 @@ spec:
                   httpGet:
                     path: /ping
                     port: *port
+                    httpHeaders:
+                      - name: Host
+                        value: localhost
                   periodSeconds: 10
                   timeoutSeconds: 5
                   failureThreshold: 5

--- a/kubernetes/apps/default/radarr-se/app/helmrelease.yaml
+++ b/kubernetes/apps/default/radarr-se/app/helmrelease.yaml
@@ -26,7 +26,9 @@ spec:
               RADARR__AUTH__REQUIRED: DisabledForLocalAddresses
               RADARR__LOG__DBENABLED: "False"
               RADARR__LOG__LEVEL: info
+              RADARR__SERVER__ALLOWEDHOSTS: "{{ .Release.Name }}.${SECRET_DOMAIN},radarr-se.default.svc.cluster.local"
               RADARR__SERVER__PORT: &port 80
+              RADARR__SERVER__TRUSTEDNETWORKS: 10.69.0.0/16
               RADARR__UPDATE__BRANCH: develop
               TZ: Pacific/Auckland
             envFrom:
@@ -46,6 +48,9 @@ spec:
                   httpGet:
                     path: /ping
                     port: *port
+                    httpHeaders:
+                      - name: Host
+                        value: localhost
                   periodSeconds: 10
                   timeoutSeconds: 5
                   failureThreshold: 5

--- a/kubernetes/apps/default/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/radarr/app/helmrelease.yaml
@@ -26,7 +26,9 @@ spec:
               RADARR__AUTH__REQUIRED: DisabledForLocalAddresses
               RADARR__LOG__DBENABLED: "False"
               RADARR__LOG__LEVEL: info
+              RADARR__SERVER__ALLOWEDHOSTS: "{{ .Release.Name }}.${SECRET_DOMAIN},radarr.default.svc.cluster.local"
               RADARR__SERVER__PORT: &port 80
+              RADARR__SERVER__TRUSTEDNETWORKS: 10.69.0.0/16
               RADARR__UPDATE__BRANCH: develop
               TZ: Pacific/Auckland
             envFrom:
@@ -46,6 +48,9 @@ spec:
                   httpGet:
                     path: /ping
                     port: *port
+                    httpHeaders:
+                      - name: Host
+                        value: localhost
                   periodSeconds: 10
                   timeoutSeconds: 5
                   failureThreshold: 5


### PR DESCRIPTION
Mirrors sonarr's host-filtering setup on radarr, radarr-se, and prowlarr, which now run versions supporting it (Radarr 6.4.3.10645, Prowlarr 2.6.3.5592):

- `*__SERVER__ALLOWEDHOSTS`: the app's route hostname plus its cluster FQDN — covers the envoy-internal route and the in-cluster consumers, which address these apps by full FQDN (recyclarr's configs are in-repo evidence).
- `*__SERVER__TRUSTEDNETWORKS: 10.69.0.0/16`: trusts forwarded headers from the pod network so `DisabledForLocalAddresses` sees real client addresses.
- Readiness probes gain a `Host: localhost` header — the kubelet probes with the pod IP as Host, which host filtering rejects.

Runtime-configured consumers (bazarr, seerr, agregarr, maintainerr) must use the full FQDN for these apps too; sonarr has run this shape without integration breakage, which suggests they already do. After reconcile, their built-in connection tests confirm it. Adapted from https://www.github.com/onedr0p/home-ops/pull/11629.
