### PR TITLE
docs: true-up mise lockfile and kopiur quirks, sharpen six cold-reader traps

### DIFF
--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -72,33 +72,33 @@ url_api = "https://api.github.com/repos/sigstore/cosign/releases/assets/50328620
 provenance = "cosign"
 
 [[tools.flux2]]
-version = "2.9.4"
+version = "2.9.5"
 backend = "aqua:fluxcd/flux2"
-specifiers = ["2.9.4"]
+specifiers = ["2.9.5"]
 
 [tools.flux2."platforms.linux-arm64"]
-checksum = "sha256:dcab945f8d8658662fa1db93e150a602ba1f91da367a82e099bd65595fc7c62c"
-url = "https://github.com/fluxcd/flux2/releases/download/v2.9.4/flux_2.9.4_linux_arm64.tar.gz"
-url_api = "https://api.github.com/repos/fluxcd/flux2/releases/assets/505259828"
+checksum = "sha256:f3e159af616ec0b9bd0a405c2185cf09d06b74652c1de3c7f377e8166826651a"
+url = "https://github.com/fluxcd/flux2/releases/download/v2.9.5/flux_2.9.5_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/fluxcd/flux2/releases/assets/538282890"
 
 [tools.flux2."platforms.linux-arm64".provenance.slsa]
-url = "https://github.com/fluxcd/flux2/releases/download/v2.9.4/provenance.intoto.jsonl"
+url = "https://github.com/fluxcd/flux2/releases/download/v2.9.5/provenance.intoto.jsonl"
 
 [tools.flux2."platforms.linux-x64"]
-checksum = "sha256:c2c397a52930f52d2005c01d276116b059d062de379386d58e98115380a766a2"
-url = "https://github.com/fluxcd/flux2/releases/download/v2.9.4/flux_2.9.4_linux_amd64.tar.gz"
-url_api = "https://api.github.com/repos/fluxcd/flux2/releases/assets/505259827"
+checksum = "sha256:b853df82adfd7736f580692f9f734473d571606307139f8fd20c2a80dd1ff473"
+url = "https://github.com/fluxcd/flux2/releases/download/v2.9.5/flux_2.9.5_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/fluxcd/flux2/releases/assets/538282891"
 
 [tools.flux2."platforms.linux-x64".provenance.slsa]
-url = "https://github.com/fluxcd/flux2/releases/download/v2.9.4/provenance.intoto.jsonl"
+url = "https://github.com/fluxcd/flux2/releases/download/v2.9.5/provenance.intoto.jsonl"
 
 [tools.flux2."platforms.macos-arm64"]
-checksum = "sha256:5350675411f1c8c20fb7fd827450933e939f7ab82a2cd92f8fa2abe497761911"
-url = "https://github.com/fluxcd/flux2/releases/download/v2.9.4/flux_2.9.4_darwin_arm64.tar.gz"
-url_api = "https://api.github.com/repos/fluxcd/flux2/releases/assets/505259822"
+checksum = "sha256:2869ef7151a6f1b27e6b5d2a6804f3ef23c7bdaa06a74e00d3fe5bfc646547fd"
+url = "https://github.com/fluxcd/flux2/releases/download/v2.9.5/flux_2.9.5_darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/fluxcd/flux2/releases/assets/538282876"
 
 [tools.flux2."platforms.macos-arm64".provenance.slsa]
-url = "https://github.com/fluxcd/flux2/releases/download/v2.9.4/provenance.intoto.jsonl"
+url = "https://github.com/fluxcd/flux2/releases/download/v2.9.5/provenance.intoto.jsonl"
 
 [[tools."github:home-operations/flate"]]
 version = "0.6.1"

--- a/README.md
+++ b/README.md
@@ -114,9 +114,11 @@ Pull request checks and reviewers are:
 | `Konflate`           | Required | Renders manifests, posts diffs, and verifies images. |
 | `Renovate PR Review` | Advisory | Reviews eligible Renovate PRs with Claude.           |
 
-`Render` is a GitHub-hosted post-merge alarm that runs Flate against `main`
-after changes under `kubernetes/`. It does not replace Konflate as the pull
-request render and diff gate.
+`Render` is a GitHub-hosted post-merge check that runs Flate (the local
+render tool) against `main` after changes under `kubernetes/`. Its failures
+surface only when watched — post-merge breakage otherwise reaches
+Alertmanager through Flux. It does not replace Konflate as the pull request
+render and diff gate.
 
 `Label Sync` keeps repository labels consistent.
 
@@ -126,8 +128,11 @@ repository conventions.
 ## Local Workflow
 
 Local environment variables and repo toolchain activation are defined in
-`.mise/config.toml`; local secrets and auth state such as `age.key`,
-`kubeconfig`, `talosconfig`, and `.secrets.env` are ignored by Git.
+`.mise/config.toml`; tools install pinned and checksum-verified against the
+committed `.mise/mise.lock`. The default environment carries the read-only
+cluster identities; `MISE_ENV=admin` selects the administrative credentials.
+Local secrets and auth state such as `age.key`, `kubeconfig`, `talosconfig`,
+and `.secrets.env` are ignored by Git.
 
 Useful entry points:
 

--- a/docs/guides/app-pattern.md
+++ b/docs/guides/app-pattern.md
@@ -14,7 +14,9 @@ cluster see [`cluster-model.md`](cluster-model.md); for validation commands see
 - `.github/labels.yaml`: label definitions synced by CI.
 - `.github/workflows/`: Lint, Image Pull, the post-merge Render alarm,
   Renovate, Renovate PR Review, and Label Sync.
-- `.mise/config.toml`: repo-pinned tool versions and local environment.
+- `.mise/`: repo-pinned tools and local environment — `config.toml` (tools
+  plus the default read-only identities), `config.admin.toml` (administrative
+  profile), and `mise.lock` (committed checksum lockfile).
 - `.renovaterc.json5`: Renovate configuration.
 - `bootstrap/`: one-time cluster bootstrap helpers.
 - `docs/`: durable documentation, including ADRs, guides, and operations docs.

--- a/docs/guides/cluster-model.md
+++ b/docs/guides/cluster-model.md
@@ -29,7 +29,9 @@ firmware, boot, and hang-at-reboot recovery see
    directory into the target namespace.
 
 Nothing reaches the cluster except through this path. Imperative changes are
-diagnostics-only; Flux overwrites drift on the next reconcile.
+diagnostics-only; Flux overwrites drift on the next reconcile of the owning
+Kustomization. A suspend blocks that reconcile and persists until resumed —
+imperative state is a lease, not a lock.
 
 ## Reconciliation ordering and `dependsOn`
 
@@ -38,8 +40,9 @@ only on new evidence — a controller behaviour change or an actual incident —
 never on taste.
 
 The rule, in one sentence: a Kustomization whose product is instances of an
-operator's API depends on the Kustomization that ships the operator (a
-separate CRD chart sits one rung below its operator); everything else gets
+operator's API depends on the Kustomization that ships the operator (and an
+operator whose CRDs ship in a separate CRD chart depends on that chart);
+everything else gets
 no edge unless it meets the evidence-based exception below. A component's
 product means its declared purpose, not whichever resource kind is most
 numerous. Supporting defaults:
@@ -50,8 +53,8 @@ numerous. Supporting defaults:
   component's CRs incidentally is a consumer, not an instance component,
   and gets no edge — availability edges cost real blocking, as the
   2026-08-28 Ceph maintenance showed for 22 apps (PR #1877).
-- Cross-family APIs are present before Flux through one of three bootstrap
-  mechanisms: `bootstrap/helmfile/crds.yaml`, a whole-product install in
+- APIs one component family consumes from another (cross-family APIs) are
+  present before Flux through one of three bootstrap mechanisms: `bootstrap/helmfile/crds.yaml`, a whole-product install in
   the bootstrap apps phase, or platform/machine bootstrap (currently
   `talos.dev`, installed by Talos machine configuration). Flux/Helm keep
   CRD upgrade ownership. Coverage was manually verified at #1887; no

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -36,9 +36,9 @@ directory when possible:
 mise exec -- kubectl kustomize kubernetes/apps/<namespace>/<app>/app
 ```
 
-`kubectl apply --dry-run=server` runs admission with the caller's own
-permissions, and the ambient kubeconfig is read-only, so a server dry-run
-needs the administrative identity named explicitly:
+`kubectl apply --dry-run=server` needs the same RBAC verbs as a real apply
+even though nothing is persisted, and the ambient kubeconfig is read-only, so
+a server dry-run needs the administrative identity named explicitly:
 `mise exec -- kubectl --kubeconfig ./kubeconfig apply --dry-run=server ...`
 (the flag, not the environment — mise overrides an exported `KUBECONFIG`).
 
@@ -46,8 +46,9 @@ needs the administrative identity named explicitly:
 
 The rendered `FluxInstance` pins its sync source to the remote `main` branch.
 Flate follows that source when resolving child Kustomization content, so a
-successful local run proves the committed baseline is renderable but can miss
-branch-only changes beneath those child paths. Do not cite it as branch-diff
+successful local run proves the baseline on the remote `main` branch is
+renderable — not your branch's commits — and can miss branch-only changes
+beneath those child paths. Do not cite it as branch-diff
 evidence without first proving the changed objects appear in its output. Use
 the Konflate pull-request render, or an explicitly branch-aware disposable
 render, as the authority for those changes.
@@ -161,10 +162,13 @@ tasks may be useful later for small, non-mutating validation aliases, but add
 them only when they reduce duplication and do not blur the operator safety
 boundary.
 
-If this repo adopts a committed `mise.lock`, treat it as a reproducibility and
-supply-chain decision. Renovate can update mise config and lockfiles, but
-lockfile refresh requires running `mise lock`, so enable that only after the
-Renovate execution model has been reviewed.
+The committed `.mise/mise.lock` pins per-platform checksums, URLs, and
+provenance for every tool; `mise install` verifies against it locally and in
+CI. The shared lefthook `mise-lock` hook refreshes it on any local commit
+touching the mise config. Renovate updates the lock alongside tool bumps on
+freshly rebased branches; a mise PR created before the lockfile landed
+updates only the config, leaving the lock behind until the next refresh —
+rebase such PRs rather than merging them stale.
 
 ## Bypass merges
 

--- a/docs/operations/storage-and-backups.md
+++ b/docs/operations/storage-and-backups.md
@@ -227,7 +227,7 @@ the repository phase and breaker metrics instead.
 
 ## Known Quirks
 
-Rechecked on 2026-08-11 against 0.10.0 source. The live rollout verified
+Rechecked on 2026-09-02 against 0.10.6 source. The live rollout verified
 repository, policy, schedule and backup paths; maintenance and restore quirks
 below remain source-verified rather than re-exercised. Re-test runtime
 observations after upgrades and file upstream if one still bites.
@@ -249,18 +249,12 @@ observations after upgrades and file upstream if one still bites.
 - `Restore` exposes `status.progress`, but the mover deliberately does not
   populate it as of 0.10.0, and terminal status carries no stats. Verify a
   restore from the target PVC's contents, not from CR counters.
-- Restore movers warn `status.resolved read failed` on every `fromPolicy`
-  restore: the mover GETs the parent `Restore` main resource, but its RBAC
-  grants only the `/status` subresource. Restores still succeed, but a retried
-  restore pod re-resolves latest instead of reusing the pinned snapshot. Do not
-  widen mover RBAC locally; the read belongs on the status subresource — an
-  upstream fix.
 - A repository whose `<repo>-discovery` Job exhausted `backoffLimit` on a
   terminal-class failure (bad credentials, locked repository) parks
   `Failed`/`Stalled`. From 0.10.0, a spec edit changes the repository generation
   and immediately recycles a stale generation-stamped Job. A Secret-only
   credential fix does not change the generation and still waits for the
-  finished Job's TTL, two hours by default; deleting the Job retries
+  finished Job's TTL, one hour by default; deleting the Job retries
   immediately. One terminal Job created before the 0.10.0 upgrade has no
   generation stamp and can behave the old way once. From 0.9.3, outage-class
   failures instead recycle automatically into the `Degraded` retry loop and


### PR DESCRIPTION
Second staleness sweep plus a cold-reader pass.

True-ups:

- validation.md's lockfile paragraph was written pre-adoption; it now describes the committed lock, the lefthook refresh hook, and the live gap — mise PRs created before the lockfile update config only, so rebase them rather than merging stale.
- README: `mise install` now verifies against the committed lock; the default environment is the read-only identities with `MISE_ENV=admin` for administrative credentials; Render's failures surface only when watched.
- app-pattern.md's `.mise/` entry covers all three files, not just config.toml.
- storage-and-backups.md: quirks recheck bumped to 0.10.6 source; the mover `status.resolved` RBAC-warning quirk retired (fixed upstream in 0.10.4); the discovery-Job TTL corrected to one hour.

Cold-reader fixes, each where a new operator would misread a fact: flate renders remote `main`, not your branch; the CRD-chart dependency direction spelled out; suspend named as the exception to drift-overwrite; "cross-family" defined at first use; server dry-run needing apply-grade RBAC despite persisting nothing.

Checked clean against everything else this week changed: probe norms (the add-app skill's "like atuin" reference is self-updating), the request cohorts, the coredns rollback, the tmpfs renames, and the ruleset changes — the durable docs either don't mention those surfaces or already say the right thing.
