### PR TITLE
feat(flux): extend cosign verification to high-risk chart sources

### DIFF
--- a/kubernetes/apps/external-secrets/external-secrets/app/ocirepository.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 2.10.0
   url: oci://ghcr.io/external-secrets/charts/external-secrets
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/external-secrets/external-secrets/\\.github/workflows/helm\\.yml@refs/heads/main$"

--- a/kubernetes/apps/kopiur-system/kopiur/app/ocirepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 0.10.6
   url: oci://ghcr.io/home-operations/charts/kopiur
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/home-operations/kopiur/\\.github/workflows/release\\.yaml@refs/tags/[0-9]+\\.[0-9]+\\.[0-9]+$"

--- a/kubernetes/apps/kube-system/cilium/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 1.20.1
   url: oci://quay.io/cilium/charts/cilium
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/cilium/cilium/\\.github/workflows/release\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/kube-system/coredns/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 1.46.2
   url: oci://ghcr.io/coredns/charts/coredns
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/coredns/helm/\\.github/workflows/release\\.yaml@refs/heads/master$"

--- a/kubernetes/apps/kube-system/snapshot-controller/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 0.1.0
   url: oci://ghcr.io/home-operations/charts/snapshot-controller
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/home-operations/helm-charts/\\.github/workflows/release\\.yaml@refs/tags/snapshot-controller-[0-9]+\\.[0-9]+\\.[0-9]+$"

--- a/kubernetes/apps/network/cloudflare-dns/app/ocirepository.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 1.21.1
   url: oci://ghcr.io/home-operations/charts-mirror/external-dns
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/home-operations/charts-mirror/\\.github/workflows/app-builder\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/network/cloudflare-tunnel/app/ocirepository.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 5.1.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/bjw-s-labs/helm-charts/\\.github/workflows/chart-release-steps\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/network/unifi-dns/app/ocirepository.yaml
+++ b/kubernetes/apps/network/unifi-dns/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 1.21.1
   url: oci://ghcr.io/home-operations/charts-mirror/external-dns
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/home-operations/charts-mirror/\\.github/workflows/app-builder\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 1.0.4
   url: oci://ghcr.io/home-operations/charts-mirror/ceph-csi-drivers
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/home-operations/charts-mirror/\\.github/workflows/app-builder\\.yaml@refs/heads/main$"

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: v1.20.6
   url: oci://ghcr.io/rook/rook-ceph
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/rook/rook/\\.github/workflows/push-build\\.yaml@refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+$"

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: v1.20.6
   url: oci://ghcr.io/rook/rook-ceph-cluster
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/rook/rook/\\.github/workflows/push-build\\.yaml@refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+$"

--- a/kubernetes/apps/system-upgrade/tuppr/app/ocirepository.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 0.5.2
   url: oci://ghcr.io/home-operations/charts/tuppr
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/home-operations/tuppr/\\.github/workflows/release\\.yaml@refs/tags/[0-9]+\\.[0-9]+\\.[0-9]+$"


### PR DESCRIPTION
The high-risk batch from #1894: twelve OCIRepository sources gain identity-bound cosign verify blocks — secrets (external-secrets), CNI (cilium), DNS (coredns and both external-dns mirrors), storage and backup (the rook-ceph pair, ceph-csi-drivers, snapshot-controller, kopiur), plus the two held over by decision: cloudflare-tunnel as the sole public ingress and tuppr as the Talos upgrade driver.

Every identity was re-validated today against the currently pinned artifact — kopiur at the just-merged 0.10.6, coredns at the rolled-back 1.46.2. `cosign verify` passes end to end under the exact issuer and subject regexes in these manifests for all ten unique artifacts. The four sources whose signing status was uncertain (cilium, coredns, external-secrets, rook) all turned out signed; the exclusions inventory is unchanged, and cert-manager's static-key exclusion is re-confirmed at v1.21.1.

Two records worth naming: cilium is reusable-workflow custody despite signing from its own repo — its release workflow is publicly callable, and the caller is not expressible in Flux's matcher; and the charts-mirror identity signs in two formats (legacy `.sig` for external-dns, v3 bundle for ceph-csi-drivers) under one subject.

A verification failure freezes that source without touching the running release; #1894's abort condition stands.
