### PR TITLE
feat(flux): verify the bootstrap-critical flux chart sources

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/app/ocirepository.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 0.59.0
   url: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-instance
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/controlplaneio-fluxcd/charts/\\.github/workflows/release\\.yml@refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+$"

--- a/kubernetes/apps/flux-system/flux-operator/app/ocirepository.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 0.59.0
   url: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: "^https://token\\.actions\\.githubusercontent\\.com$"
+        subject: "^https://github\\.com/controlplaneio-fluxcd/charts/\\.github/workflows/release\\.yml@refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+$"


### PR DESCRIPTION
The final phase of #1894: flux-operator and flux-instance gain verify blocks pinned to the controlplaneio-fluxcd charts release identity — the ADR-0003 canonical example. Both verified end to end at 0.59.0. The two charts sign from a single workflow run, and the certificate's tag is the charts repo's own release tag, so the regex anchors the `v`-prefixed pattern without tying it to chart versions.

Scope note for the record: these blocks guard day-2 reconciliation, where source-controller fetches the charts. The helmfile bootstrap path installs the same pinned charts directly through helm, outside Flux, where no verification runs — initial bootstrap trust remains a documented gap, not a solved one.
